### PR TITLE
Update README.md, fixed MessageBuilder example

### DIFF
--- a/src/Mailgun/Messages/README.md
+++ b/src/Mailgun/Messages/README.md
@@ -45,7 +45,7 @@ $messageBldr->setDeliveryTime("tomorrow 8:00AM", "PST");
 $messageBldr->setClickTracking(true);
 
 # Finally, send the message.
-$mg->post('{$domain}/messages', $messageBldr->getMessage());
+$mg->post("{$domain}/messages", $messageBldr->getMessage());
 ```
 
 Available Functions


### PR DESCRIPTION
The $domain element was not processed in the single quotes. Changed to double quotes.
