### PR TITLE
Fixed missing IDs for batch message recipients. Closes #15.

### DIFF
--- a/src/Mailgun/Messages/BatchMessage.php
+++ b/src/Mailgun/Messages/BatchMessage.php
@@ -36,7 +36,9 @@ class BatchMessage extends MessageBuilder{
 		}
 		
 		$this->addRecipient("to", $address, $variables);
-		$attributes["id"] = $this->toRecipientCount;
+		if(!array_key_exists("id", $variables)){
+			$variables['id'] = $this->toRecipientCount;
+		} 
 		$this->batchRecipientAttributes["$address"] = $variables;
 	}
 	

--- a/tests/Mailgun/Tests/Messages/BatchMessageTest.php
+++ b/tests/Mailgun/Tests/Messages/BatchMessageTest.php
@@ -59,6 +59,16 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase{
         $property->setAccessible(true);
         $this->assertEquals(1, $property->getValue($message));
     }
+    public function testDefaultIDInVariables() {
+        $message = $this->client->BatchMessage($this->sampleDomain);
+        $message->addToRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+        
+        $reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('batchRecipientAttributes');
+        $property->setAccessible(True);
+        $propertyValue = $property->getValue($message);
+        $this->assertEquals(1, $propertyValue['test-user@samples.mailgun.org']['id']);
+    }
 }
 ?>
 


### PR DESCRIPTION
Checking to see if the ID is set, otherwise, add the recipient count # to the ID. This way each recipient is numbered. Tests also included!
