### PR TITLE
Refactored counters, batch job trigger adjustment, all recipient types i...

### DIFF
--- a/tests/Mailgun/Tests/Messages/BatchMessageTest.php
+++ b/tests/Mailgun/Tests/Messages/BatchMessageTest.php
@@ -15,11 +15,56 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase{
 		$message = $this->client->BatchMessage($this->sampleDomain);
 		$this->assertTrue(is_array($message->getMessage()));
 	}
-	public function testaddToRecipient(){
+	public function testAddRecipient(){
 		$message = $this->client->BatchMessage($this->sampleDomain);
 		$message->addToRecipient("test@samples.mailgun.org", array("first" => "Test", "last" => "User"));
 		$messageObj= $message->getMessage();
 		$this->assertEquals(array("to" => array("'Test User' <test@samples.mailgun.org>")), $messageObj);
+
+		$reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('counters');
+        $property->setAccessible(true);
+        $array = $property->getValue($message);
+        $this->assertEquals(1, $array['recipients']['to']);
+	}
+	public function testRecipientVariablesOnTo(){
+		$message = $this->client->BatchMessage($this->sampleDomain);
+		$message->addToRecipient("test@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+		$messageObj= $message->getMessage();
+		$this->assertEquals(array("to" => array("'Test User' <test@samples.mailgun.org>")), $messageObj);
+		
+		$reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('batchRecipientAttributes');
+        $property->setAccessible(true);
+        $propertyValue = $property->getValue($message);
+        $this->assertEquals("Test", $propertyValue['test@samples.mailgun.org']['first']);
+        $this->assertEquals("User", $propertyValue['test@samples.mailgun.org']['last']);
+	}
+	public function testRecipientVariablesOnCc(){
+		$message = $this->client->BatchMessage($this->sampleDomain);
+		$message->addCcRecipient("test@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+		$messageObj= $message->getMessage();
+		$this->assertEquals(array("cc" => array("'Test User' <test@samples.mailgun.org>")), $messageObj);
+		
+		$reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('batchRecipientAttributes');
+        $property->setAccessible(true);
+        $propertyValue = $property->getValue($message);
+        $this->assertEquals("Test", $propertyValue['test@samples.mailgun.org']['first']);
+        $this->assertEquals("User", $propertyValue['test@samples.mailgun.org']['last']);
+	}
+	public function testRecipientVariablesOnBcc(){
+		$message = $this->client->BatchMessage($this->sampleDomain);
+		$message->addBccRecipient("test@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+		$messageObj= $message->getMessage();
+		$this->assertEquals(array("bcc" => array("'Test User' <test@samples.mailgun.org>")), $messageObj);
+		
+		$reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('batchRecipientAttributes');
+        $property->setAccessible(true);
+        $propertyValue = $property->getValue($message);
+        $this->assertEquals("Test", $propertyValue['test@samples.mailgun.org']['first']);
+        $this->assertEquals("User", $propertyValue['test@samples.mailgun.org']['last']);
 	}
 	public function testAddMultipleBatchRecipients(){
 		$message = $this->client->BatchMessage($this->sampleDomain);
@@ -40,7 +85,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase{
 		$messageObj= $message->getMessage();
 		$this->assertEquals(1, count($messageObj["to"]));
 	}
-	public function testResetOnEndBatchMessage(){
+	public function testAttributeResetOnEndBatchMessage(){
 		$message = $this->client->BatchMessage($this->sampleDomain);
 		$message->addToRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
 		$message->setFromAddress("samples@mailgun.org", array("first" => "Test", "last" => "User"));
@@ -50,15 +95,6 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase{
 		$messageObj= $message->getMessage();
 		$this->assertTrue(true, empty($messageObj));
 	}
-    public function testToRecipientCount() {
-        $message = $this->client->BatchMessage($this->sampleDomain);
-        $message->addToRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
-        
-        $reflectionClass = new \ReflectionClass(get_class($message));
-        $property = $reflectionClass->getProperty('toRecipientCount');
-        $property->setAccessible(true);
-        $this->assertEquals(1, $property->getValue($message));
-    }
     public function testDefaultIDInVariables() {
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addToRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));

--- a/tests/Mailgun/Tests/Messages/MessageBuilderTest.php
+++ b/tests/Mailgun/Tests/Messages/MessageBuilderTest.php
@@ -13,7 +13,21 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase{
 		$message = $this->client->MessageBuilder();
 		$this->assertTrue(is_array($message->getMessage()));
 	}
-	
+	public function testCountersSetToZero(){
+		$message = $this->client->MessageBuilder();
+
+		$reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('counters');
+        $property->setAccessible(True);
+        $propertyValue = $property->getValue($message);
+        $this->assertEquals(0, $propertyValue['recipients']['to']);
+        $this->assertEquals(0, $propertyValue['recipients']['cc']);
+        $this->assertEquals(0, $propertyValue['recipients']['bcc']);
+        $this->assertEquals(0, $propertyValue['attributes']['attachment']);
+        $this->assertEquals(0, $propertyValue['attributes']['campaign_id']);
+        $this->assertEquals(0, $propertyValue['attributes']['custom_option']);
+		$this->assertEquals(0, $propertyValue['attributes']['tag']);
+	}
 	public function testAddToRecipient(){
 		$message = $this->client->MessageBuilder();
 		$message->addToRecipient("test@samples.mailgun.org", array("first" => "Test", "last" => "User"));
@@ -32,6 +46,36 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase{
 		$messageObj = $message->getMessage();
 		$this->assertEquals(array("bcc" => array("'Test User' <test@samples.mailgun.org>")), $messageObj);
 	}
+    public function testToRecipientCount() {
+        $message = $this->client->MessageBuilder();
+        $message->addToRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+        
+        $reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('counters');
+        $property->setAccessible(true);
+        $array = $property->getValue($message);
+        $this->assertEquals(1, $array['recipients']['to']);
+    }
+    public function testCcRecipientCount() {
+        $message = $this->client->MessageBuilder();
+        $message->addCcRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+        
+        $reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('counters');
+        $property->setAccessible(true);
+        $array = $property->getValue($message);
+        $this->assertEquals(1, $array['recipients']['cc']);
+    }
+    public function testBccRecipientCount() {
+        $message = $this->client->MessageBuilder();
+        $message->addBccRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+        
+        $reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('counters');
+        $property->setAccessible(true);
+        $array = $property->getValue($message);
+        $this->assertEquals(1, $array['recipients']['bcc']);
+    }
 	public function testSetFromAddress(){
 		$message = $this->client->MessageBuilder();
 		$message->setFromAddress("test@samples.mailgun.org", array("first" => "Test", "last" => "User"));


### PR DESCRIPTION
- Counters are now an array, to make it easier to check and update values. 
- Batch sending now triggers on 1,000 recipients of any type (to, cc, bcc)
- Exception will be thrown in Message Builder if any recipient type exceeds 1,000. (Use a batch job instead)
- Recipient variables are added to the batch job, regardless of recipient type.
- Tests for all the above.
- Fixes #17 
