### PR TITLE
BatchMessage Improvements

### DIFF
--- a/src/Mailgun/Messages/BatchMessage.php
+++ b/src/Mailgun/Messages/BatchMessage.php
@@ -84,12 +84,15 @@ class BatchMessage extends MessageBuilder{
 			$this->counters['recipients']['bcc'] = 0;
 			unset($this->message["to"]);
 			array_push($this->messageIds, $response->http_response_body->id);
-			return $this->messageIds;
 		}
 	}
 	
 	public function finalize(){
 		return $this->sendMessage();
+	}
+
+	public function getMessageIds(){
+		return $this->messageIds;
 	}
 }
 ?>

--- a/tests/Mailgun/Tests/Messages/BatchMessageTest.php
+++ b/tests/Mailgun/Tests/Messages/BatchMessageTest.php
@@ -105,6 +105,16 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase{
         $propertyValue = $property->getValue($message);
         $this->assertEquals(1, $propertyValue['test-user@samples.mailgun.org']['id']);
     }
+    public function testgetMessageIds() {
+        $message = $this->client->BatchMessage($this->sampleDomain);
+        $message->addToRecipient("test-user@samples.mailgun.org", array("first" => "Test", "last" => "User"));
+        $message->setFromAddress("samples@mailgun.org", array("first" => "Test", "last" => "User"));
+		$message->setSubject("This is the subject of the message!");
+		$message->setTextBody("This is the text body of the message!");
+        $message->finalize();
+
+        $this->assertEquals(array("1234"), $message->getMessageIds());
+    }
 }
 ?>
 


### PR DESCRIPTION
- Removed the return from Send_Message(). You don't call that directly. 
- Added method to return Message IDs after a Batch Send event.
