### PR TITLE
Add ability to disable SSL

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -20,9 +20,9 @@ class RestClient{
 	private $apiKey;
 	protected $mgClient;
 	
-	public function __construct($apiKey, $apiEndpoint, $apiVersion){	
+	public function __construct($apiKey, $apiEndpoint, $apiVersion, $ssl){
 		$this->apiKey = $apiKey;
-		$this->mgClient = new Guzzle('https://' . $apiEndpoint . '/' . $apiVersion . '/');
+		$this->mgClient = new Guzzle($this->generateEndpoint($apiEndpoint, $apiVersion, $ssl));
 		$this->mgClient->setDefaultOption('curl.options', array('CURLOPT_FORBID_REUSE' => true));
 		$this->mgClient->setDefaultOption('auth', array (API_USER, $this->apiKey));	
 		$this->mgClient->setDefaultOption('exceptions', false);
@@ -96,6 +96,15 @@ class RestClient{
 		}
 		$result->http_response_code = $httpResponseCode;
 		return $result;
+	}
+
+	private function generateEndpoint($apiEndpoint, $apiVersion, $ssl){
+		if(!$ssl){
+			return "http://" . $apiEndpoint . "/" . $apiVersion . "/";
+		}
+		else{
+			return "https://" . $apiEndpoint . "/" . $apiVersion . "/";
+		}
 	}
 }
 

--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -22,8 +22,8 @@ class Mailgun{
     protected $workingDomain;
     protected $restClient;
     
-    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v2"){
-	    $this->restClient = new RestClient($apiKey, $apiEndpoint, $apiVersion);
+    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v2", $ssl = true){
+	    $this->restClient = new RestClient($apiKey, $apiEndpoint, $apiVersion, $ssl);
     }
 
 	public function sendMessage($workingDomain, $postData, $postFiles = array()){


### PR DESCRIPTION
It would be helpful to allow disablement of SSL for testing against an postbin or something else. This pull request adds the ability to disable SSL while preserving backward compatibility. 

Simply instantiate the client like this: 

```
$mg = new Mailgun("api-key-here", "host-to-interact-with.com", "v2", false);
```
