### PR TITLE
Depend on guzzle  >=3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mailgun/mailgun-php",
     "description": "The Mailgun SDK provides methods for all API functions.",
     "require": {
-        "guzzle/guzzle": "3.8.*"
+        "guzzle/guzzle": "<4.0,>=3.8"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
As guzzle 3.9.\* is out, mailgun should support it as well - else it
creates conflicts on larger projects.
