### PR TITLE
Add Mailgun->verifyWebhookSignature()

### DIFF
--- a/tests/Mailgun/Tests/MailgunTest.php
+++ b/tests/Mailgun/Tests/MailgunTest.php
@@ -13,6 +13,26 @@ class MailgunTest extends \Mailgun\Tests\MailgunTestCase
         $client = new Mailgun();
         $client->sendMessage("test.mailgun.com", "etss", 1);
     }
+
+    public function testVerifyWebhookGood() {
+        $client = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+        $postData = [
+            'timestamp' => '1403645220',
+            'token' => '5egbgr1vjgqxtrnp65xfznchgdccwh5d6i09vijqi3whgowmn6',
+            'signature' => '9cfc5c41582e51246e73c88d34db3af0a3a2692a76fbab81492842f000256d33',
+        ];
+        assert($client->verifyWebhookSignature($postData));
+    }
+
+    public function testVerifyWebhookBad() {
+        $client = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+        $postData = [
+            'timestamp' => '1403645220',
+            'token' => 'owyldpe6nxhmrn78epljl6bj0orrki1u3d2v5e6cnlmmuox8jr',
+            'signature' => '9cfc5c41582e51246e73c88d34db3af0a3a2692a76fbab81492842f000256d33',
+        ];
+        assert(!$client->verifyWebhookSignature($postData));
+    }
 }
 
 ?>


### PR DESCRIPTION
It would save a lot of development time (added up over all the projects)
to have a function to verify the webhook signature in the library.  This
will also be more conducive to secure implementations, since only the
library developers have to figure out how to do a constant-time
comparison.

I've implemented this function as a method on the Mailgun object and
provided two unit tests.  The current implementation uses hash_equals
(the constant-time comparison function introduced in PHP 5.6) to compare
the hashes if it is available and falls back to the == operator
otherwise.
