### PR TITLE
Don't require @ prefix for attachment filenames

### DIFF
--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -169,26 +169,22 @@ class MessageBuilder
 
     public function addAttachment($attachmentPath, $attachmentName = null)
     {
-        if (preg_match("/^@/", $attachmentPath)) {
-            if (isset($this->files["attachment"])) {
-                $attachment = array(
+        if (isset($this->files["attachment"])) {
+            $attachment = array(
+                'filePath'   => $attachmentPath,
+                'remoteName' => $attachmentName
+            );
+            array_push($this->files["attachment"], $attachment);
+        } else {
+            $this->files["attachment"] = array(
+                array(
                     'filePath'   => $attachmentPath,
                     'remoteName' => $attachmentName
-                );
-                array_push($this->files["attachment"], $attachment);
-            } else {
-                $this->files["attachment"] = array(
-                    array(
-                        'filePath'   => $attachmentPath,
-                        'remoteName' => $attachmentName
-                    )
-                );
-            }
-
-            return true;
-        } else {
-            throw new InvalidParameter(INVALID_PARAMETER_ATTACHMENT);
+                )
+            );
         }
+
+        return true;
     }
 
     public function addInlineImage($inlineImagePath, $inlineImageName = null)


### PR DESCRIPTION
After using `Mailgun::sendMessage()` directly and attaching files via the `$postFiles` parameter, I was surprised to get an `InvalidParameter` exception when passing identical parameters into `MessageBuilder::addAttachment()`. 

I'm guessing there was a reason to require the "@" prefix, but I don't know what it is, and everything that I tried works without it. Moreover, `Guzzle\Http\Message\PostFile::setFilename()` simply strips the "@" first thing without doing anything with it. (See https://github.com/guzzle/guzzle3/blob/master/src/Guzzle/Http/Message/PostFile.php#L48).

This PR is to make `addAttachment()` behave consistently with `$postFiles` by not requiring the "@" prefix.
