### PR TITLE
Allow any data type for custom data

### DIFF
--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -314,15 +314,7 @@ class MessageBuilder
 
     public function addCustomData($customName, $data)
     {
-        if (is_array($data)) {
-            $jsonArray                         = json_encode($data);
-            $this->message['v:' . $customName] = $jsonArray;
-
-            return $this->message['v:' . $customName];
-        } else {
-            throw new InvalidParameter(INVALID_PARAMETER_NON_ARRAY);
-        }
-
+        $this->message['v:' . $customName] = json_encode($data);
     }
 
     public function addCustomParameter($parameterName, $data)


### PR DESCRIPTION
Since a "v:custom-name" header can have any JSON-encoded value and can be used multiple times, `MessageBuilder::addCustomData()` shouldn't require an array. I've tested, and bypassing the message builder to manually pass in non-array variables works just fine.

See http://documentation.mailgun.com/user_manual.html#attaching-data-to-messages
