### PR TITLE
On GET, pass options directly to Guzzle; don't add manually

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -91,12 +91,7 @@ class RestClient{
 	}
 	
 	public function get($endpointUrl, $queryString = array()){
-		$request = $this->mgClient->get($endpointUrl);
-		if(isset($queryString)){
-			foreach($queryString as $key=>$value){
-				$request->getQuery()->set($key, $value);
-			}			
-		}
+		$request = $this->mgClient->get($endpointUrl, null, $queryString);
 		$response = $request->send();
 		return $this->responseHandler($response);
 	}


### PR DESCRIPTION
This PR is to fix an intermittent bug when sending filter parameters in a GET request.

For some reason, the manner in which parameters were added to the Guzzle request caused some of my API calls to not return data. Specifically, any request to the Events API that included a negative event type filter, e.g., "-stored", would come back with an empty `items` array. I tried using Guzzle directly and got the same result.

This returns a valid response with paging, but no event items:

``` php
$params = array('event' => 'accepted -stored');
$client = new \Guzzle\Http\Client('https://api.mailgun.net/v2/');
$client->setDefaultOption('auth', array('api', '[api-key]'));
$request = $client->get('[my-domain]');
foreach($params as $key => $value){
    $request->getQuery()->set($key, $value);
}
$response = $request->send();
```

However, I found out that passing `$params` straight into `get()` solved the problem:

``` php
$params = array('event' => 'accepted -stored');
$client = new \Guzzle\Http\Client('https://api.mailgun.net/v2/');
$client->setDefaultOption('auth', array('api', '[api-key]'));
$request = $client->get('[my-domain]', null, $params);
$response = $request->send();
```

For the record, I'm using Guzzle 3.9.2, and don't know it well enough to comment on why one method works and the other doesn't, but ditching the `$request->getQuery()->set($key, $value)` solved my problem. And as an added bonus, it makes the code more succinct.
