### PR TITLE
Fix for #71: Show response message on 400, 401 and 404.

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -199,13 +199,13 @@ class RestClient {
 		return $result;
 	}
 
-    protected function getResponseExceptionMessage(\Guzzle\Http\Message\Response $responseObj){
-        $body = (string)$responseObj->getBody();
-        $response = json_decode($body);
-        if (json_last_error() == JSON_ERROR_NONE && isset($response->message)) {
-            return " " . $response->message;
-        }
-    }
+	protected function getResponseExceptionMessage(\Guzzle\Http\Message\Response $responseObj){
+		$body = (string)$responseObj->getBody();
+		$response = json_decode($body);
+		if (json_last_error() == JSON_ERROR_NONE && isset($response->message)) {
+			return " " . $response->message;
+		}
+	}
 
     /**
      * @param string $apiEndpoint

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -176,21 +176,30 @@ class RestClient {
      */
 	public function responseHandler($responseObj){
 		$httpResponseCode = $responseObj->getStatusCode();
+        $data = (string) $responseObj->getBody();
+        $jsonResponseData = json_decode($data, false);
 		if($httpResponseCode === 200){
-			$data = (string) $responseObj->getBody();
-			$jsonResponseData = json_decode($data, false);
 			$result = new \stdClass();
 			// return response data as json if possible, raw if not
 			$result->http_response_body = $data && $jsonResponseData === null ? $data : $jsonResponseData;
 		}
 		elseif($httpResponseCode == 400){
-			throw new MissingRequiredParameters(ExceptionMessages::EXCEPTION_MISSING_REQUIRED_PARAMETERS);
+			throw new MissingRequiredParameters(
+                EXCEPTION_MISSING_REQUIRED_PARAMETERS .
+                "\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+            );
 		}
 		elseif($httpResponseCode == 401){
-			throw new InvalidCredentials(ExceptionMessages::EXCEPTION_INVALID_CREDENTIALS);
+			throw new InvalidCredentials(
+                EXCEPTION_INVALID_CREDENTIALS  .
+                "\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+            );
 		}
 		elseif($httpResponseCode == 404){
-			throw new MissingEndpoint(ExceptionMessages::EXCEPTION_MISSING_ENDPOINT);
+			throw new MissingEndpoint(
+                EXCEPTION_MISSING_ENDPOINT  .
+                "\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+            );
 		}
 		else{
 			throw new GenericHTTPError(ExceptionMessages::EXCEPTION_GENERIC_HTTP_ERROR, $httpResponseCode, $responseObj->getBody());

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -176,30 +176,21 @@ class RestClient {
      */
 	public function responseHandler($responseObj){
 		$httpResponseCode = $responseObj->getStatusCode();
-		$data = (string) $responseObj->getBody();
-		$jsonResponseData = json_decode($data, false);
 		if($httpResponseCode === 200){
+			$data = (string) $responseObj->getBody();
+			$jsonResponseData = json_decode($data, false);
 			$result = new \stdClass();
 			// return response data as json if possible, raw if not
 			$result->http_response_body = $data && $jsonResponseData === null ? $data : $jsonResponseData;
 		}
 		elseif($httpResponseCode == 400){
-			throw new MissingRequiredParameters(
-				EXCEPTION_MISSING_REQUIRED_PARAMETERS .
-				"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
-			);
+			throw new MissingRequiredParameters(EXCEPTION_MISSING_REQUIRED_PARAMETERS . $this->getResponseExceptionMessage($responseObj));
 		}
 		elseif($httpResponseCode == 401){
-			throw new InvalidCredentials(
-				EXCEPTION_INVALID_CREDENTIALS  .
-				"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
-			);
+			throw new InvalidCredentials(EXCEPTION_INVALID_CREDENTIALS);
 		}
 		elseif($httpResponseCode == 404){
-			throw new MissingEndpoint(
-				EXCEPTION_MISSING_ENDPOINT  .
-				"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
-			);
+			throw new MissingEndpoint(EXCEPTION_MISSING_ENDPOINT  . $this->getResponseExceptionMessage($responseObj));
 		}
 		else{
 			throw new GenericHTTPError(ExceptionMessages::EXCEPTION_GENERIC_HTTP_ERROR, $httpResponseCode, $responseObj->getBody());
@@ -207,6 +198,14 @@ class RestClient {
 		$result->http_response_code = $httpResponseCode;
 		return $result;
 	}
+
+    protected function getResponseExceptionMessage(\Guzzle\Http\Message\Response $responseObj){
+        $body = (string)$responseObj->getBody();
+        $response = json_decode($body);
+        if (json_last_error() == JSON_ERROR_NONE && isset($response->message)) {
+            return " " . $response->message;
+        }
+    }
 
     /**
      * @param string $apiEndpoint

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -176,8 +176,8 @@ class RestClient {
      */
 	public function responseHandler($responseObj){
 		$httpResponseCode = $responseObj->getStatusCode();
-        $data = (string) $responseObj->getBody();
-        $jsonResponseData = json_decode($data, false);
+		$data = (string) $responseObj->getBody();
+		$jsonResponseData = json_decode($data, false);
 		if($httpResponseCode === 200){
 			$result = new \stdClass();
 			// return response data as json if possible, raw if not
@@ -185,21 +185,21 @@ class RestClient {
 		}
 		elseif($httpResponseCode == 400){
 			throw new MissingRequiredParameters(
-                EXCEPTION_MISSING_REQUIRED_PARAMETERS .
-                "\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
-            );
+            	EXCEPTION_MISSING_REQUIRED_PARAMETERS .
+            	"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+			);
 		}
 		elseif($httpResponseCode == 401){
 			throw new InvalidCredentials(
-                EXCEPTION_INVALID_CREDENTIALS  .
-                "\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
-            );
+            	EXCEPTION_INVALID_CREDENTIALS  .
+            	"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+			);
 		}
 		elseif($httpResponseCode == 404){
 			throw new MissingEndpoint(
-                EXCEPTION_MISSING_ENDPOINT  .
-                "\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
-            );
+            	EXCEPTION_MISSING_ENDPOINT  .
+            	"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+			);
 		}
 		else{
 			throw new GenericHTTPError(ExceptionMessages::EXCEPTION_GENERIC_HTTP_ERROR, $httpResponseCode, $responseObj->getBody());

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -185,20 +185,20 @@ class RestClient {
 		}
 		elseif($httpResponseCode == 400){
 			throw new MissingRequiredParameters(
-            	EXCEPTION_MISSING_REQUIRED_PARAMETERS .
-            	"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+				EXCEPTION_MISSING_REQUIRED_PARAMETERS .
+				"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
 			);
 		}
 		elseif($httpResponseCode == 401){
 			throw new InvalidCredentials(
-            	EXCEPTION_INVALID_CREDENTIALS  .
-            	"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+				EXCEPTION_INVALID_CREDENTIALS  .
+				"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
 			);
 		}
 		elseif($httpResponseCode == 404){
 			throw new MissingEndpoint(
-            	EXCEPTION_MISSING_ENDPOINT  .
-            	"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
+				EXCEPTION_MISSING_ENDPOINT  .
+				"\n" . 'Response: "' . $data && $jsonResponseData === null ? $data : $jsonResponseData->message .'"'
 			);
 		}
 		else{

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -199,6 +199,10 @@ class RestClient {
 		return $result;
 	}
 
+    /**
+     * @param \Guzzle\Http\Message\Response $responseObj
+     * @return string
+     */
 	protected function getResponseExceptionMessage(\Guzzle\Http\Message\Response $responseObj){
 		$body = (string)$responseObj->getBody();
 		$response = json_decode($body);

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -184,13 +184,13 @@ class RestClient {
 			$result->http_response_body = $data && $jsonResponseData === null ? $data : $jsonResponseData;
 		}
 		elseif($httpResponseCode == 400){
-			throw new MissingRequiredParameters(EXCEPTION_MISSING_REQUIRED_PARAMETERS . $this->getResponseExceptionMessage($responseObj));
+			throw new MissingRequiredParameters(ExceptionMessages::EXCEPTION_MISSING_REQUIRED_PARAMETERS . $this->getResponseExceptionMessage($responseObj));
 		}
 		elseif($httpResponseCode == 401){
-			throw new InvalidCredentials(EXCEPTION_INVALID_CREDENTIALS);
+			throw new InvalidCredentials(ExceptionMessages::EXCEPTION_INVALID_CREDENTIALS);
 		}
 		elseif($httpResponseCode == 404){
-			throw new MissingEndpoint(EXCEPTION_MISSING_ENDPOINT  . $this->getResponseExceptionMessage($responseObj));
+			throw new MissingEndpoint(ExceptionMessages::EXCEPTION_MISSING_ENDPOINT  . $this->getResponseExceptionMessage($responseObj));
 		}
 		else{
 			throw new GenericHTTPError(ExceptionMessages::EXCEPTION_GENERIC_HTTP_ERROR, $httpResponseCode, $responseObj->getBody());


### PR DESCRIPTION
Adds the actual response message to the errors thrown on 400, 401 and
404 response codes. This provides a lot more useful info than the
current messages. The message doesn’t really give you much to go on. I
spent hours trying to find what I did wrong, double checking my API
keys and looking up the error on google.