### PR TITLE
Updated default API version from v2 to v3

### DIFF
--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -33,7 +33,7 @@ class Mailgun{
      * @param string $apiVersion
      * @param bool $ssl
      */
-    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v2", $ssl = true){
+    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v3", $ssl = true){
         $this->apiKey = $apiKey;
         $this->restClient = new RestClient($apiKey, $apiEndpoint, $apiVersion, $ssl);
     }

--- a/tests/Mailgun/Tests/Mock/Connection/TestBroker.php
+++ b/tests/Mailgun/Tests/Mock/Connection/TestBroker.php
@@ -9,7 +9,7 @@ class TestBroker extends RestClient
 
     protected $apiEndpoint;
 
-    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v2")
+    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v3")
     {
         $this->apiKey      = $apiKey;
         $this->apiEndpoint = $apiEndpoint;

--- a/tests/Mailgun/Tests/Mock/Mailgun.php
+++ b/tests/Mailgun/Tests/Mock/Mailgun.php
@@ -10,7 +10,7 @@ class Mailgun extends Base
     protected $debug;
     protected $restClient;
 
-    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v2")
+    public function __construct($apiKey = null, $apiEndpoint = "api.mailgun.net", $apiVersion = "v3")
     {
         $this->restClient = new TestBroker($apiKey, $apiEndpoint, $apiVersion);
     }


### PR DESCRIPTION
As read on http://blog.mailgun.com/default-api-version-now-v3/ the default API version is now 3.

I noticed this update was not reflected in this repository, so i decided to create my first ever pull request with this small edit!