### PR TITLE
Fix notices on empty webhook requests

### DIFF
--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -85,6 +85,9 @@ class Mailgun{
         if(is_null($postData)) {
             $postData = $_POST;
         }
+        if(!isset($postData['timestamp']) || !isset($postData['token']) || !isset($postData['signature'])) {
+            return false;
+        }
         $hmac = hash_hmac('sha256', "{$postData["timestamp"]}{$postData["token"]}", $this->apiKey);
         $sig = $postData['signature'];
         if(function_exists('hash_equals')) {

--- a/tests/Mailgun/Tests/MailgunTest.php
+++ b/tests/Mailgun/Tests/MailgunTest.php
@@ -33,4 +33,10 @@ class MailgunTest extends \Mailgun\Tests\MailgunTestCase
         );
         assert(!$client->verifyWebhookSignature($postData));
     }
+
+    public function testVerifyWebhookEmptyRequest() {
+        $client = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+        $postData = array();
+        assert(!$client->verifyWebhookSignature($postData));
+    }
 }


### PR DESCRIPTION
If someone invokes the webhook verification routine without any POST data, three notices are thrown:

    PHP Notice:  Undefined index: timestamp in /home/z38/dev/mailgun-php/src/Mailgun/Mailgun.php on line 91
    PHP Stack trace:
    PHP   1. {main}() /home/z38/dev/mailgun-php/test.php:0
    PHP   2. Mailgun\Mailgun->verifyWebhookSignature() /home/z38/dev/mailgun-php/test.php:7
    PHP Notice:  Undefined index: token in /home/z38/dev/mailgun-php/src/Mailgun/Mailgun.php on line 91
    PHP Stack trace:
    PHP   1. {main}() /home/z38/dev/mailgun-php/test.php:0
    PHP   2. Mailgun\Mailgun->verifyWebhookSignature() /home/z38/dev/mailgun-php/test.php:7
    PHP Notice:  Undefined index: signature in /home/z38/dev/mailgun-php/src/Mailgun/Mailgun.php on line 92
    PHP Stack trace:
    PHP   1. {main}() /home/z38/dev/mailgun-php/test.php:0
    PHP   2. Mailgun\Mailgun->verifyWebhookSignature() /home/z38/dev/mailgun-php/test.php:7

After applying this patch, the verification routine simply returns `false` for such requests.