### PR TITLE
Add function to configure Guzzle's default options, so the user can set the Guzzle timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ $mg->get("$domain/log", array('limit' => 25,
                               'skip'  => 0));
 ```
 
+Guzzle Configuration
+--------------------
+
+Mailgun uses Guzzle to handle HTTP requests.  Here's how you would configure the default options
+for Guzzle...
+
+```$mg = new MailGun('key-example');
+
+$mg->configureRestClient(array(
+    'timeout' => 300,
+    'connect_timeout' => 300
+));
+```
+
+For a complete list of Guzzle options see the [Guzzle options page](https://guzzle.readthedocs.org/en/latest/request-options.html).
+
 Response
 --------
 
@@ -164,15 +180,6 @@ to send a message, by calling a methods for each parameter.
 Batch Message is an extension of Message Builder, and allows you to easily send 
 a batch message job within a few seconds. The complexity of 
 batch messaging is eliminated! 
-
-Framework integration
----------------------
-
-If you are using a framework you might consider these composer packages to make the framework integration easier. 
-
-* [tehplague/swiftmailer-mailgun-bundle](https://github.com/tehplague/swiftmailer-mailgun-bundle) for Symfony2
-* [Bogardo/Mailgun](https://github.com/Bogardo/Mailgun) for Laravel 4
-* [katanyoo/yii2-mailgun-mailer](https://github.com/katanyoo/yii2-mailgun-mailer) for Yii2
 
 Support and Feedback
 --------------------

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ Batch Message is an extension of Message Builder, and allows you to easily send
 a batch message job within a few seconds. The complexity of 
 batch messaging is eliminated! 
 
+Framework integration
+---------------------
+
+If you are using a framework you might consider these composer packages to make the framework integration easier. 
+
+* [tehplague/swiftmailer-mailgun-bundle](https://github.com/tehplague/swiftmailer-mailgun-bundle) for Symfony2
+* [Bogardo/Mailgun](https://github.com/Bogardo/Mailgun) for Laravel 4
+* [katanyoo/yii2-mailgun-mailer](https://github.com/katanyoo/yii2-mailgun-mailer) for Yii2
+
 Support and Feedback
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Guzzle Configuration
 Mailgun uses Guzzle to handle HTTP requests.  Here's how you would configure the default options
 for Guzzle...
 
-```$mg = new MailGun('key-example');
+```PHP
+$mg = new MailGun('key-example');
 
 $mg->configureRestClient(array(
     'timeout' => 300,

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -51,6 +51,10 @@ class RestClient
         ]);
     }
 
+    public function setDefaultOption($option, $value) {
+        $this->mgClient->setDefaultOption($option, $value);
+    }
+
     /**
      * @param string $endpointUrl
      * @param array  $postData

--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -39,6 +39,20 @@ class Mailgun{
     }
 
     /**
+     *  This function allows the configuration of the RestClient, for example
+     *  the "timeout" and "connnect_timeout" options of Guzzle.  See here for
+     *  list of options accepted by Guzzle.
+     *  https://guzzle.readthedocs.org/en/latest/request-options.html
+     *
+     * @param array $config
+     */
+    public function configureRestClient(array $config) {
+        foreach($config as $option => $value) {
+            $this->restClient->setDefaultOption($option, $value);
+        }
+    }
+
+    /**
      *  This function allows the sending of a fully formed message OR a custom
      *  MIME string. If sending MIME, the string must be passed in to the 3rd
      *  position of the function call.


### PR DESCRIPTION
I have added a function to RestClient.php which would allow the user to configure the default options that the Guzzle client uses.  I then added a function to Mailgun.php which would let the user pass in an array of Guzzle options.  See the README file for an example.

The purpose for this, is that by default, Guzzle requests wait indefinitely.  This was causing my application to halt, because for some reason I wasn't getting a response when making requests.

As a side note, I believe it would be a good idea to add default values for "timeout" and "connect_timeout" in the RestClient.php constructor.  However, I think that might be considered a "breaking change" so I didn't add it.