### PR TITLE
Update RestClient.php

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -159,7 +159,7 @@ class RestClient
     public function responseHandler($responseObj)
     {
         $httpResponseCode = $responseObj->getStatusCode();
-        if ($httpResponseCode === 200) {
+        if ($httpResponseCode == 200) {
             $data = (string) $responseObj->getBody();
             $jsonResponseData = json_decode($data, false);
             $result = new \stdClass();


### PR DESCRIPTION
The comparison does not need to be "if ($httpResponseCode === 200)".  This fails because $httpResponseCode may come back as a string.
This caused error in my Laravel installation. 

"if ($httpResponseCode == 200)" is all that is required.