### PR TITLE
Updated minimum PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "guzzlehttp/guzzle": "~5.0"
     },
     "require-dev": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "phpunit/phpunit": "~4.6"
     },
     "autoload": {


### PR DESCRIPTION
Because the library uses the short array syntax ``[]``, vs ``array()``.