### PR TITLE
Updated composer to pull latest version 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer and the Mailgun SDK.
 curl -sS https://getcomposer.org/installer | php
 
 # Add Mailgun as a dependency
-php composer.phar require mailgun/mailgun-php:~1.7.2
+php composer.phar require mailgun/mailgun-php:~1.8
 ``` 
 
 **For shared hosts without SSH access, check out our [Shared Host Instructions](SharedHostInstall.md).**


### PR DESCRIPTION
The documentation was instructing to pull 1.7.2 but the current version is 1.8. Some things such as bounces have errors on older versions so it would be better for people to download 1.8 to avoid issues with the latest features.

It would be great if the Library Download link (line 30) was updated too but I do not know the link to 1.8