### PR TITLE
Declare endpointUrl field

### DIFF
--- a/src/Mailgun/Messages/BatchMessage.php
+++ b/src/Mailgun/Messages/BatchMessage.php
@@ -39,6 +39,11 @@ class BatchMessage extends MessageBuilder{
      * @var array
      */
 	private $messageIds = array();
+	
+    /**
+     * @var string 
+     */
+	private $endpointUrl;
 
     /**
      * @param \Mailgun\Connection\RestClient $restClient


### PR DESCRIPTION
To avoid `field declared dynamically` and `field not found` warnings in IDEs