### PR TITLE
Strict check of signature

### DIFF
--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -96,7 +96,7 @@ class Mailgun{
             return hash_equals($hmac, $sig);
         }
         else {
-            return ($hmac == $sig);
+            return ($hmac === $sig);
         }
     }
 


### PR DESCRIPTION
Strict compare of signature with the computed value, to fix the a security risk.

Previously fixed vulnerability:
- https://github.com/laravel/laravel/commit/ba0cf2a1c9280e99d39aad5d4d686d554941eea1
- [wordpress #28054](https://core.trac.wordpress.org/changeset/28054) ([CVE-2014-0166](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0166))

Related discussions:
- https://news.ycombinator.com/item?id=9484757
- https://medium.com/@barryvdh/csrf-protection-in-laravel-explained-146d89ff1357