### PR TITLE
add header and convert arrays for put method

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -182,7 +182,16 @@ class RestClient
      */
     public function put($endpointUrl, $putData)
     {
-        return $this->send('PUT', $endpointUrl, $putData);
+        if (is_array($putData)) {
+            $headers['Content-Type'] = 'application/x-www-form-urlencoded';
+            $urlencodedPutData = '';
+            foreach ($putData as $key => $value) {
+                $urlencodedPutData .= urlencode($key) . '=' . urlencode($value) . '&';
+            }
+            $putData = trim($urlencodedPutData,'&');
+        }
+
+        return $this->send('PUT', $endpointUrl, $putData, [], $headers);
     }
 
     /**


### PR DESCRIPTION
Re: Issue https://github.com/mailgun/mailgun-php/issues/122

Since the upgrade to v2 and using ```$client = new \Http\Adapter\Guzzle6\Client();```
```./vendor/guzzlehttp/psr7/src/functions.php``` has a function called ```stream_for``` at line 77, which checks the type of the $resource passed to it (in our case this is the $body of our PUT request), and rejects it if it is an array. We can convert the array to send the $body as a urlencoded string, 'name=Bob&subscribed=false' along with setting a content-type header of ```application/x-www-form-urlencoded```