### PR TITLE
Add new package in Framework integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ If you are using a framework you might consider these composer packages to make 
 * [tehplague/swiftmailer-mailgun-bundle](https://github.com/tehplague/swiftmailer-mailgun-bundle) for Symfony2
 * [Bogardo/Mailgun](https://github.com/Bogardo/Mailgun) for Laravel 4
 * [katanyoo/yii2-mailgun-mailer](https://github.com/katanyoo/yii2-mailgun-mailer) for Yii2
+* [narendravaghela/cakephp-mailgun](https://github.com/narendravaghela/cakephp-mailgun) for CakePHP 3
 
 Support and Feedback
 --------------------


### PR DESCRIPTION
I have created a plugin for CakePHP to send emails using Mailgun SDK and added the reference to package in readme file.