### PR TITLE
Updated docblock for sendMessage 

### DIFF
--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -47,8 +47,8 @@ class Mailgun{
      *  MIME string. If sending MIME, the string must be passed in to the 3rd
      *  position of the function call.
      *
-     * @param $workingDomain
-     * @param $postData
+     * @param string $workingDomain
+     * @param array $postData
      * @param array $postFiles
      * @return \stdClass
      * @throws Exceptions\MissingRequiredMIMEParameters

--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -47,9 +47,10 @@ class Mailgun{
      *  MIME string. If sending MIME, the string must be passed in to the 3rd
      *  position of the function call.
      *
-     * @param string $workingDomain
-     * @param array $postData
+     * @param $workingDomain
+     * @param $postData
      * @param array $postFiles
+     * @return \stdClass
      * @throws Exceptions\MissingRequiredMIMEParameters
      */
     public function sendMessage($workingDomain, $postData, $postFiles = array()){


### PR DESCRIPTION
Updated the docblock to include what the `\Mailgun\Mailgun::sendMessage` returns and throws. 
Mentioned in issue #120 

