### PR TITLE
Build a string query form array

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -62,7 +62,7 @@ class RestClient
     /**
      * @param string $method
      * @param string $uri
-     * @param array  $body
+     * @param mixed  $body
      * @param array  $files
      * @param array  $headers
      *
@@ -81,6 +81,8 @@ class RestClient
         if (!empty($files)) {
             $body = new MultipartStream($files);
             $headers['Content-Type'] = 'multipart/form-data; boundary='.$body->getBoundary();
+        } elseif (is_array($body)) {
+            $body = http_build_query($body);
         }
 
         $request = new Request($method, $this->getApiUrl($uri), $headers, $body);
@@ -101,7 +103,7 @@ class RestClient
      * @throws MissingEndpoint
      * @throws MissingRequiredParameters
      */
-    public function post($endpointUrl, $postData = array(), $files = array())
+    public function post($endpointUrl, array $postData = array(), $files = array())
     {
         $postFiles = [];
 
@@ -171,7 +173,7 @@ class RestClient
 
     /**
      * @param string $endpointUrl
-     * @param array  $putData
+     * @param mixed  $putData
      *
      * @return \stdClass
      *

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -83,6 +83,7 @@ class RestClient
             $headers['Content-Type'] = 'multipart/form-data; boundary='.$body->getBoundary();
         } elseif (is_array($body)) {
             $body = http_build_query($body);
+            $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
         $request = new Request($method, $this->getApiUrl($uri), $headers, $body);

--- a/tests/Mailgun/Tests/Mock/Connection/TestBroker.php
+++ b/tests/Mailgun/Tests/Mock/Connection/TestBroker.php
@@ -19,7 +19,7 @@ class TestBroker extends RestClient
         $this->apiEndpoint = $apiHost;
     }
 
-    public function post($endpointUrl, $postData = array(), $files = array())
+    public function post($endpointUrl, array $postData = array(), $files = array())
     {
         return $this->testResponseHandler($endpointUrl, $httpResponseCode = 200);
     }


### PR DESCRIPTION
Fix issue #122

If the $body is an array we make sure to build in to a string query and add the correct header