### PR TITLE
Apply PSR Standards to tests/ too

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 
 //Grab the composer Autoloader!
-$autoloader = require dirname(__DIR__).'/vendor/autoload.php';
+$autoloader = include dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
| Q             | A      |
|---------------|--------|
| Branch        | v2.1.2 |
| Bug fix?      | No     |
| New feature?  | No     |
| BC breaks?    | No     |
| Deprecations? | No     |
| Tests pass?   | Yes    |
| Fixed tickets |     |
| License       |        |
| Doc PR        |        |

## Description

As part of the PSR Standards, reported by PHP Code Sniffer, we should use `include` instead of `require` when possible, so this PR is applying this update.