### PR TITLE
Fixed inline/attachment issue. Added new tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 composer.lock
 nbproject/*
 .idea
+phpunit.phar

--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -119,8 +119,10 @@ class RestClient
         foreach ($fields as $fieldName) {
             if (isset($files[$fieldName])) {
                 if (is_array($files[$fieldName])) {
+                    $fileIndex = 0;
                     foreach ($files[$fieldName] as $file) {
-                        $postFiles[] = $this->prepareFile($fieldName, $file);
+                        $postFiles[] = $this->prepareFile($fieldName, $file, $fileIndex);
+                        $fileIndex++;
                     }
                 } else {
                     $postFiles[] = $this->prepareFile($fieldName, $files[$fieldName]);
@@ -251,10 +253,11 @@ class RestClient
      *
      * @param string       $fieldName
      * @param string|array $filePath
+     * @param integer      $fileIndex
      *
      * @return array
      */
-    protected function prepareFile($fieldName, $filePath)
+    protected function prepareFile($fieldName, $filePath, $fileIndex = 0)
     {
         $filename = null;
         // Backward compatibility code
@@ -267,6 +270,9 @@ class RestClient
         if (strpos($filePath, '@') === 0) {
             $filePath = substr($filePath, 1);
         }
+
+        // Add index for multiple file support
+        $fieldName .= '[' . $fileIndex . ']';
 
         return [
             'name'     => $fieldName,


### PR DESCRIPTION
Hello Friends!

This pull request fixes a multi inline/attachment issue. Some HTTP clients cannot handle url encoded form data with the same key and different value. With the current implementation, if you pass in multiple inline/attachment values, only the last value in the array is actually sent to the Mailgun API.

We need to give the key an "index marker" (for lack of better term?). The Mailgun API knows how to handle this...

Example (Bad):
```
inline=blah&inline=blah
```

Example (Good):
```
inline[0]=blah&inline[1]=blah
```

Also, tests. I'm including my lame attempt at revamping the tests a bit. Eventually, every test should probably follow something like this, so as to test between request and "$client->send()". Happy to entertain any community suggestions here. We really need to beef up the tests on this SDK.