### PR TITLE
Make sure $variables is an array in addRecipient()

### DIFF
--- a/src/Mailgun/Messages/BatchMessage.php
+++ b/src/Mailgun/Messages/BatchMessage.php
@@ -97,7 +97,7 @@ class BatchMessage extends MessageBuilder
 
         if (array_key_exists($headerName, $this->counters['recipients'])) {
             $this->counters['recipients'][$headerName] += 1;
-            if (!array_key_exists('id', $variables)) {
+            if (is_array($variables) && !array_key_exists('id', $variables)) {
                 $variables['id'] = $this->counters['recipients'][$headerName];
             }
         }

--- a/tests/Messages/BatchMessageTest.php
+++ b/tests/Messages/BatchMessageTest.php
@@ -41,6 +41,20 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $this->assertEquals(1, $array['recipients']['to']);
     }
 
+    public function testAddRecipientWithoutFirstAndLastName()
+    {
+        $message = $this->client->BatchMessage($this->sampleDomain);
+        $message->addToRecipient('test@samples.mailgun.org', 'this-is-not-an-array');
+        $messageObj = $message->getMessage();
+        $this->assertEquals(['to' => ["test@samples.mailgun.org"]], $messageObj);
+
+        $reflectionClass = new \ReflectionClass(get_class($message));
+        $property = $reflectionClass->getProperty('counters');
+        $property->setAccessible(true);
+        $array = $property->getValue($message);
+        $this->assertEquals(1, $array['recipients']['to']);
+    }
+
     public function testRecipientVariablesOnTo()
     {
         $message = $this->client->BatchMessage($this->sampleDomain);

--- a/tests/Messages/BatchMessageTest.php
+++ b/tests/Messages/BatchMessageTest.php
@@ -46,7 +46,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addToRecipient('test@samples.mailgun.org', 'this-is-not-an-array');
         $messageObj = $message->getMessage();
-        $this->assertEquals(['to' => ["test@samples.mailgun.org"]], $messageObj);
+        $this->assertEquals(['to' => ['test@samples.mailgun.org']], $messageObj);
 
         $reflectionClass = new \ReflectionClass(get_class($message));
         $property = $reflectionClass->getProperty('counters');


### PR DESCRIPTION
This PR is replacing the old one (https://github.com/mailgun/mailgun-php/pull/118) providing the expected PHPUnit test to validate the update, and make sure we get a valid response when we don't provide an array with the first name and last name.

This PR is a request of @Nyholm asking for a Pull Request that has the expected tests too.