### PR TITLE
Messages api

### DIFF
--- a/src/Mailgun/Api/Domain.php
+++ b/src/Mailgun/Api/Domain.php
@@ -49,7 +49,7 @@ class Domain extends HttpApi
 
         $response = $this->httpGet('/v3/domains', $params);
 
-        return $this->deserializer->deserialize($response, IndexResponse::class);
+        return $this->safeDeserialize($response, IndexResponse::class);
     }
 
     /**
@@ -65,7 +65,7 @@ class Domain extends HttpApi
 
         $response = $this->httpGet(sprintf('/v3/domains/%s', $domain));
 
-        return $this->deserializer->deserialize($response, ShowResponse::class);
+        return $this->safeDeserialize($response, ShowResponse::class);
     }
 
     /**
@@ -114,7 +114,7 @@ class Domain extends HttpApi
 
         $response = $this->httpDelete(sprintf('/v3/domains/%s', $domain));
 
-        return $this->deserializer->deserialize($response, DeleteResponse::class);
+        return $this->safeDeserialize($response, DeleteResponse::class);
     }
 
     /**
@@ -165,7 +165,7 @@ class Domain extends HttpApi
 
         $response = $this->httpPost(sprintf('/v3/domains/%s/credentials', $domain), $params);
 
-        return $this->deserializer->deserialize($response, CreateCredentialResponse::class);
+        return $this->safeDeserialize($response, CreateCredentialResponse::class);
     }
 
     /**
@@ -190,7 +190,7 @@ class Domain extends HttpApi
 
         $response = $this->httpPut(sprintf('/v3/domains/%s/credentials/%s', $domain, $login), $params);
 
-        return $this->deserializer->deserialize($response, UpdateCredentialResponse::class);
+        return $this->safeDeserialize($response, UpdateCredentialResponse::class);
     }
 
     /**
@@ -214,7 +214,7 @@ class Domain extends HttpApi
             )
         );
 
-        return $this->deserializer->deserialize($response, DeleteCredentialResponse::class);
+        return $this->safeDeserialize($response, DeleteCredentialResponse::class);
     }
 
     /**
@@ -230,7 +230,7 @@ class Domain extends HttpApi
 
         $response = $this->httpGet(sprintf('/v3/domains/%s/connection', $domain));
 
-        return $this->deserializer->deserialize($response, ConnectionResponse::class);
+        return $this->safeDeserialize($response, ConnectionResponse::class);
     }
 
     /**
@@ -261,6 +261,6 @@ class Domain extends HttpApi
 
         $response = $this->httpPut(sprintf('/v3/domains/%s/connection', $domain), $params);
 
-        return $this->deserializer->deserialize($response, UpdateConnectionResponse::class);
+        return $this->safeDeserialize($response, UpdateConnectionResponse::class);
     }
 }

--- a/src/Mailgun/Api/HttpApi.php
+++ b/src/Mailgun/Api/HttpApi.php
@@ -107,9 +107,7 @@ abstract class HttpApi
      */
     protected function httpPost($path, array $parameters = [], array $requestHeaders = [])
     {
-        $body = http_build_query($parameters);
-        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
-        return $this->httpPostRaw($path, $body, $requestHeaders);
+        return $this->httpPostRaw($path, $this->createJsonBody($parameters), $requestHeaders);
     }
 
     /**
@@ -145,10 +143,9 @@ abstract class HttpApi
      */
     protected function httpPut($path, array $parameters = [], array $requestHeaders = [])
     {
-        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         try {
             $response = $this->httpClient->sendRequest(
-                $this->requestBuilder->create('PUT', $path, $requestHeaders, http_build_query($parameters))
+                $this->requestBuilder->create('PUT', $path, $requestHeaders, $this->createJsonBody($parameters))
             );
         } catch (HttplugException\NetworkException $e) {
             throw HttpServerException::networkError($e);
@@ -168,15 +165,26 @@ abstract class HttpApi
      */
     protected function httpDelete($path, array $parameters = [], array $requestHeaders = [])
     {
-        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         try {
             $response = $this->httpClient->sendRequest(
-                $this->requestBuilder->create('DELETE', $path, $requestHeaders, http_build_query($parameters))
+                $this->requestBuilder->create('DELETE', $path, $requestHeaders, $this->createJsonBody($parameters))
             );
         } catch (HttplugException\NetworkException $e) {
             throw HttpServerException::networkError($e);
         }
 
         return $response;
+    }
+
+    /**
+     * Create a JSON encoded version of an array of parameters.
+     *
+     * @param array $parameters Request parameters
+     *
+     * @return null|string
+     */
+    protected function createJsonBody(array $parameters)
+    {
+        return (count($parameters) === 0) ? null : json_encode($parameters, empty($parameters) ? JSON_FORCE_OBJECT : 0);
     }
 }

--- a/src/Mailgun/Api/HttpApi.php
+++ b/src/Mailgun/Api/HttpApi.php
@@ -107,7 +107,9 @@ abstract class HttpApi
      */
     protected function httpPost($path, array $parameters = [], array $requestHeaders = [])
     {
-        return $this->httpPostRaw($path, $this->createJsonBody($parameters), $requestHeaders);
+        $body = http_build_query($parameters);
+        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+        return $this->httpPostRaw($path, $body, $requestHeaders);
     }
 
     /**
@@ -143,9 +145,10 @@ abstract class HttpApi
      */
     protected function httpPut($path, array $parameters = [], array $requestHeaders = [])
     {
+        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         try {
             $response = $this->httpClient->sendRequest(
-                $this->requestBuilder->create('PUT', $path, $requestHeaders, $this->createJsonBody($parameters))
+                $this->requestBuilder->create('PUT', $path, $requestHeaders, http_build_query($parameters))
             );
         } catch (HttplugException\NetworkException $e) {
             throw HttpServerException::networkError($e);
@@ -165,26 +168,15 @@ abstract class HttpApi
      */
     protected function httpDelete($path, array $parameters = [], array $requestHeaders = [])
     {
+        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         try {
             $response = $this->httpClient->sendRequest(
-                $this->requestBuilder->create('DELETE', $path, $requestHeaders, $this->createJsonBody($parameters))
+                $this->requestBuilder->create('DELETE', $path, $requestHeaders, http_build_query($parameters))
             );
         } catch (HttplugException\NetworkException $e) {
             throw HttpServerException::networkError($e);
         }
 
         return $response;
-    }
-
-    /**
-     * Create a JSON encoded version of an array of parameters.
-     *
-     * @param array $parameters Request parameters
-     *
-     * @return null|string
-     */
-    protected function createJsonBody(array $parameters)
-    {
-        return (count($parameters) === 0) ? null : json_encode($parameters, empty($parameters) ? JSON_FORCE_OBJECT : 0);
     }
 }

--- a/src/Mailgun/Api/Message.php
+++ b/src/Mailgun/Api/Message.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * Copyright (C) 2013-2016 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Api;
 
 use Mailgun\Assert;
@@ -8,8 +15,6 @@ use Mailgun\Resource\Api\Message\SendResponse;
 use Mailgun\Resource\Api\Message\ShowResponse;
 
 /**
- *
- *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class Message extends HttpApi
@@ -70,7 +75,7 @@ class Message extends HttpApi
      * Get stored message.
      *
      * @param string $url
-     * @param boolean $rawMessage if true we will use "Accept: message/rfc2822" header.
+     * @param bool   $rawMessage if true we will use "Accept: message/rfc2822" header.
      *
      * @return ShowResponse
      */
@@ -89,11 +94,11 @@ class Message extends HttpApi
     }
 
     /**
-     * Prepare a file
+     * Prepare a file.
      *
-     * @param string       $fieldName
-     * @param array $filePath array('fileContent' => 'content') or array('filePath' => '/foo/bar')
-     * @param int          $fileIndex
+     * @param string $fieldName
+     * @param array  $filePath  array('fileContent' => 'content') or array('filePath' => '/foo/bar')
+     * @param int    $fileIndex
      *
      * @return array
      *

--- a/src/Mailgun/Api/Message.php
+++ b/src/Mailgun/Api/Message.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Mailgun\Api;
+
+use Mailgun\Assert;
+use Mailgun\Exception\InvalidArgumentException;
+use Mailgun\Resource\Api\Message\SendResponse;
+use Mailgun\Resource\Api\Message\ShowResponse;
+
+/**
+ *
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Message extends HttpApi
+{
+    /**
+     * @param $domain
+     * @param array $params
+     *
+     * @return SendResponse
+     */
+    public function send($domain, array $params)
+    {
+        Assert::notEmpty($domain);
+        Assert::notEmpty($params);
+
+        $postDataMultipart = [];
+        $fields = ['message', 'attachment', 'inline'];
+        foreach ($fields as $fieldName) {
+            if (!isset($params[$fieldName])) {
+                continue;
+            }
+            if (!is_array($params[$fieldName])) {
+                $postDataMultipart[] = $this->prepareFile($fieldName, $params[$fieldName]);
+            } else {
+                $fileIndex = 0;
+                foreach ($params[$fieldName] as $file) {
+                    $postDataMultipart[] = $this->prepareFile($fieldName, $file, $fileIndex);
+                    ++$fileIndex;
+                }
+            }
+
+            unset($params[$fieldName]);
+        }
+
+        foreach ($params as $key => $value) {
+            if (is_array($value)) {
+                $index = 0;
+                foreach ($value as $subValue) {
+                    $postDataMultipart[] = [
+                        'name' => sprintf('%s[%d]', $key, $index++),
+                        'content' => $subValue,
+                    ];
+                }
+            } else {
+                $postDataMultipart[] = [
+                    'name' => $key,
+                    'content' => $value,
+                ];
+            }
+        }
+
+        $response = $this->httpPostRaw(sprintf('/v3/%s/messages', $domain), $postDataMultipart);
+
+        return $this->safeDeserialize($response, SendResponse::class);
+    }
+
+    /**
+     * Get stored message.
+     *
+     * @param string $url
+     * @param boolean $rawMessage if true we will use "Accept: message/rfc2822" header.
+     *
+     * @return ShowResponse
+     */
+    public function show($url, $rawMessage = false)
+    {
+        Assert::notEmpty($url);
+
+        $headers = [];
+        if ($rawMessage) {
+            $headers['Accept'] = 'message/rfc2822';
+        }
+
+        $response = $this->httpGet($url, [], $headers);
+
+        return $this->safeDeserialize($response, ShowResponse::class);
+    }
+
+    /**
+     * Prepare a file
+     *
+     * @param string       $fieldName
+     * @param array $filePath array('fileContent' => 'content') or array('filePath' => '/foo/bar')
+     * @param int          $fileIndex
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    private function prepareFile($fieldName, array $filePath, $fileIndex = 0)
+    {
+        // Add index for multiple file support
+        $fieldName .= '['.$fileIndex.']';
+        $filename = isset($filePath['filename']) ? $filePath['filename'] : null;
+
+        if (isset($filePath['fileContent'])) {
+            // File from memory
+            $resource = fopen('php://temp', 'r+');
+            fwrite($resource, $filePath['fileContent']);
+            rewind($resource);
+        } elseif (isset($filePath['filePath'])) {
+            // File form path
+            $path = $filePath['filePath'];
+
+            // Remove leading @ symbol
+            if (strpos($path, '@') === 0) {
+                $path = substr($path, 1);
+            }
+
+            $resource = fopen($path, 'r');
+        } else {
+            throw new InvalidArgumentException('When using a file you need to specify parameter "fileContent" or "filePath"');
+        }
+
+        return [
+            'name' => $fieldName,
+            'content' => $resource,
+            'filename' => $filename,
+        ];
+    }
+}

--- a/src/Mailgun/Api/Stats.php
+++ b/src/Mailgun/Api/Stats.php
@@ -32,7 +32,7 @@ class Stats extends HttpApi
 
         $response = $this->httpGet(sprintf('/v3/%s/stats/total', rawurlencode($domain)), $params);
 
-        return $this->deserializer->deserialize($response, TotalResponse::class);
+        return $this->safeDeserialize($response, TotalResponse::class);
     }
 
     /**
@@ -47,6 +47,6 @@ class Stats extends HttpApi
 
         $response = $this->httpGet(sprintf('/v3/%s/stats', rawurlencode($domain)), $params);
 
-        return $this->deserializer->deserialize($response, AllResponse::class);
+        return $this->safeDeserialize($response, AllResponse::class);
     }
 }

--- a/src/Mailgun/Api/Webhook.php
+++ b/src/Mailgun/Api/Webhook.php
@@ -31,7 +31,7 @@ class Webhook extends HttpApi
         Assert::notEmpty($domain);
         $response = $this->httpGet(sprintf('/v3/domains/%s/webhooks', $domain));
 
-        return $this->deserializer->deserialize($response, IndexResponse::class);
+        return $this->safeDeserialize($response, IndexResponse::class);
     }
 
     /**
@@ -46,7 +46,7 @@ class Webhook extends HttpApi
         Assert::notEmpty($webhook);
         $response = $this->httpGet(sprintf('/v3/domains/%s/webhooks/%s', $domain, $webhook));
 
-        return $this->deserializer->deserialize($response, ShowResponse::class);
+        return $this->safeDeserialize($response, ShowResponse::class);
     }
 
     /**
@@ -69,7 +69,7 @@ class Webhook extends HttpApi
 
         $response = $this->httpPost(sprintf('/v3/domains/%s/webhooks', $domain), $params);
 
-        return $this->deserializer->deserialize($response, CreateResponse::class);
+        return $this->safeDeserialize($response, CreateResponse::class);
     }
 
     /**
@@ -91,7 +91,7 @@ class Webhook extends HttpApi
 
         $response = $this->httpPut(sprintf('/v3/domains/%s/webhooks/%s', $domain, $id), $params);
 
-        return $this->deserializer->deserialize($response, UpdateResponse::class);
+        return $this->safeDeserialize($response, UpdateResponse::class);
     }
 
     /**
@@ -107,6 +107,6 @@ class Webhook extends HttpApi
 
         $response = $this->httpDelete(sprintf('/v3/domains/%s/webhooks/%s', $domain, $id));
 
-        return $this->deserializer->deserialize($response, DeleteResponse::class);
+        return $this->safeDeserialize($response, DeleteResponse::class);
     }
 }

--- a/src/Mailgun/Deserializer/ModelDeserializer.php
+++ b/src/Mailgun/Deserializer/ModelDeserializer.php
@@ -29,8 +29,9 @@ class ModelDeserializer implements ResponseDeserializer
     public function deserialize(ResponseInterface $response, $class)
     {
         $body = $response->getBody()->__toString();
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
-            throw new DeserializeException('The ModelDeserializer cannot deserialize response with Content-Type:'.$response->getHeaderLine('Content-Type'));
+        $contentType = $response->getHeaderLine('Content-Type');
+        if (strpos($contentType, 'application/json') !== 0 && strpos($contentType, 'application/octet-stream') !== 0) {
+            throw new DeserializeException('The ModelDeserializer cannot deserialize response with Content-Type: '.$contentType);
         }
 
         $data = json_decode($body, true);

--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -272,8 +272,24 @@ class Mailgun
     /**
      * @return Api\Event
      */
-    public function event()
+    public function events()
     {
         return new Api\Event($this->httpClient, $this->requestBuilder, $this->deserializer);
+    }
+
+    /**
+     * @return Api\Webhook
+     */
+    public function webhooks()
+    {
+        return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->deserializer);
+    }
+
+    /**
+     * @return Api\Message
+     */
+    public function messages()
+    {
+        return new Api\Message($this->httpClient, $this->requestBuilder, $this->deserializer);
     }
 }

--- a/src/Mailgun/Resource/Api/Message/SendResponse.php
+++ b/src/Mailgun/Resource/Api/Message/SendResponse.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * Copyright (C) 2013-2016 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Resource\Api\Message;
 
 use Mailgun\Resource\ApiResponse;

--- a/src/Mailgun/Resource/Api/Message/SendResponse.php
+++ b/src/Mailgun/Resource/Api/Message/SendResponse.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Mailgun\Resource\Api\Message;
+
+use Mailgun\Resource\ApiResponse;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class SendResponse implements ApiResponse
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @param string $id
+     * @param string $message
+     */
+    private function __construct($id, $message)
+    {
+        $this->id = $id;
+        $this->message = $message;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return SendResponse
+     */
+    public static function create(array $data)
+    {
+        $id = '';
+        $message = '';
+
+        if (isset($data['id'])) {
+            $id = $data['id'];
+        }
+        if (isset($data['message'])) {
+            $message = $data['message'];
+        }
+
+        return new self($id, $message);
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/Mailgun/Resource/Api/Message/ShowResponse.php
+++ b/src/Mailgun/Resource/Api/Message/ShowResponse.php
@@ -1,0 +1,389 @@
+<?php
+
+namespace Mailgun\Resource\Api\Message;
+
+use Mailgun\Resource\ApiResponse;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class ShowResponse implements ApiResponse
+{
+    /**
+     * Only available with message/rfc2822.
+     *
+     * @var string
+     */
+    private $recipient;
+
+    /**
+     * Only available with message/rfc2822.
+     *
+     * @var string
+     */
+    private $bodyMime;
+
+    /**
+     * @var string
+     */
+    private $recipients;
+
+    /**
+     * @var string
+     */
+    private $sender;
+
+    /**
+     * @var string
+     */
+    private $from;
+
+    /**
+     * @var string
+     */
+    private $subject;
+
+    /**
+     * @var string
+     */
+    private $bodyPlain;
+
+    /**
+     * @var string
+     */
+    private $strippedText;
+
+    /**
+     * @var string
+     */
+    private $strippedSignature;
+
+    /**
+     * @var string
+     */
+    private $bodyHtml;
+
+    /**
+     * @var string
+     */
+    private $strippedHtml;
+
+    /**
+     * @var array
+     */
+    private $attachments;
+
+    /**
+     * @var string
+     */
+    private $messageUrl;
+
+    /**
+     * @var string
+     */
+    private $contentIdMap;
+
+    /**
+     * @var array
+     */
+    private $messageHeaders;
+
+    /**
+     * Do not let this object be creted without the ::create.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return SendResponse
+     */
+    public static function create(array $data)
+    {
+        $response = new self();
+
+        if (isset($data['recipients'])) {
+            $response->setRecipients($data['recipients']);
+        }
+        if (isset($data['sender'])) {
+            $response->setSender($data['sender']);
+        }
+        if (isset($data['from'])) {
+            $response->setFrom($data['from']);
+        }
+        if (isset($data['subject'])) {
+            $response->setSubject($data['subject']);
+        }
+        if (isset($data['body-plain'])) {
+            $response->setBodyPlain($data['body-plain']);
+        }
+        if (isset($data['stripped-text'])) {
+            $response->setStrippedText($data['stripped-text']);
+        }
+        if (isset($data['stripped-signature'])) {
+            $response->setStrippedSignature($data['stripped-signature']);
+        }
+        if (isset($data['body-html'])) {
+            $response->setBodyHtml($data['body-html']);
+        }
+        if (isset($data['stripped-html'])) {
+            $response->setStrippedHtml($data['stripped-html']);
+        }
+        if (isset($data['message-url'])) {
+            $response->setMessageUrl($data['message-url']);
+        }
+        if (isset($data['message-headers'])) {
+            $response->setMessageHeaders($data['message-headers']);
+        }
+        if (isset($data['recipient'])) {
+            $response->setRecipient($data['recipient']);
+        }
+        if (isset($data['body-mime'])) {
+            $response->setBodyMime($data['body-mime']);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRecipient()
+    {
+        return $this->recipient;
+    }
+
+    /**
+     * @param string $recipient
+     */
+    private function setRecipient($recipient)
+    {
+        $this->recipient = $recipient;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodyMime()
+    {
+        return $this->bodyMime;
+    }
+
+    /**
+     * @param string $bodyMime
+     */
+    private function setBodyMime($bodyMime)
+    {
+        $this->bodyMime = $bodyMime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRecipients()
+    {
+        return $this->recipients;
+    }
+
+    /**
+     * @param string $recipients
+     */
+    private function setRecipients($recipients)
+    {
+        $this->recipients = $recipients;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSender()
+    {
+        return $this->sender;
+    }
+
+    /**
+     * @param string $sender
+     */
+    private function setSender($sender)
+    {
+        $this->sender = $sender;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * @param string $from
+     */
+    private function setFrom($from)
+    {
+        $this->from = $from;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    /**
+     * @param string $subject
+     */
+    private function setSubject($subject)
+    {
+        $this->subject = $subject;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodyPlain()
+    {
+        return $this->bodyPlain;
+    }
+
+    /**
+     * @param string $bodyPlain
+     */
+    private function setBodyPlain($bodyPlain)
+    {
+        $this->bodyPlain = $bodyPlain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStrippedText()
+    {
+        return $this->strippedText;
+    }
+
+    /**
+     * @param string $strippedText
+     */
+    private function setStrippedText($strippedText)
+    {
+        $this->strippedText = $strippedText;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStrippedSignature()
+    {
+        return $this->strippedSignature;
+    }
+
+    /**
+     * @param string $strippedSignature
+     */
+    private function setStrippedSignature($strippedSignature)
+    {
+        $this->strippedSignature = $strippedSignature;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodyHtml()
+    {
+        return $this->bodyHtml;
+    }
+
+    /**
+     * @param string $bodyHtml
+     */
+    private function setBodyHtml($bodyHtml)
+    {
+        $this->bodyHtml = $bodyHtml;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStrippedHtml()
+    {
+        return $this->strippedHtml;
+    }
+
+    /**
+     * @param string $strippedHtml
+     */
+    private function setStrippedHtml($strippedHtml)
+    {
+        $this->strippedHtml = $strippedHtml;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttachments()
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * @param array $attachments
+     */
+    private function setAttachments(array $attachments)
+    {
+        $this->attachments = $attachments;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessageUrl()
+    {
+        return $this->messageUrl;
+    }
+
+    /**
+     * @param string $messageUrl
+     */
+    private function setMessageUrl($messageUrl)
+    {
+        $this->messageUrl = $messageUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContentIdMap()
+    {
+        return $this->contentIdMap;
+    }
+
+    /**
+     * @param string $contentIdMap
+     */
+    private function setContentIdMap($contentIdMap)
+    {
+        $this->contentIdMap = $contentIdMap;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessageHeaders()
+    {
+        return $this->messageHeaders;
+    }
+
+    /**
+     * @param array $messageHeaders
+     */
+    private function setMessageHeaders(array $messageHeaders)
+    {
+        $this->messageHeaders = $messageHeaders;
+    }
+}

--- a/src/Mailgun/Resource/Api/Message/ShowResponse.php
+++ b/src/Mailgun/Resource/Api/Message/ShowResponse.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * Copyright (C) 2013-2016 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Resource\Api\Message;
 
 use Mailgun\Resource\ApiResponse;


### PR DESCRIPTION
This will add the missing Message API. The old message builders will still work. 

(Sorry for including the change to `$this->safeDeserialize($response, ...)` in this PR.)

Fixes #168