### PR TITLE
Quoting fixes

### DIFF
--- a/src/Mailgun/Messages/BatchMessage.php
+++ b/src/Mailgun/Messages/BatchMessage.php
@@ -74,7 +74,7 @@ class BatchMessage extends MessageBuilder
      * @throws MissingRequiredMIMEParameters
      * @throws TooManyParameters
      */
-    protected function addRecipient($headerName, $address, $variables)
+    protected function addRecipient($headerName, $address, $variables, $nonRecipient = false)
     {
         if (array_key_exists($headerName, $this->counters['recipients'])) {
             if ($this->counters['recipients'][$headerName] == Api::RECIPIENT_COUNT_LIMIT) {
@@ -85,7 +85,7 @@ class BatchMessage extends MessageBuilder
             }
         }
 
-        $compiledAddress = $this->parseAddress($address, $variables);
+        $compiledAddress = $this->parseAddress($address, $variables, $nonRecipient = false);
 
         if (isset($this->message[$headerName])) {
             array_push($this->message[$headerName], $compiledAddress);

--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -108,9 +108,9 @@ class MessageBuilder
             }
             $fullName = preg_replace('/(?<!\\\)"/', '\\\\\\\\\"', $fullName);
             return '"\"'.$fullName.'\""'." <$address>";
-        }        
+        }
 
-        return $address;      
+        return $address;
     }
 
     /**

--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -104,9 +104,11 @@ class MessageBuilder
         if ($fullName != null) {
             if ($nonRecipient === true) {
                 $fullName = preg_replace('/(?<!\\\)"/', '\"', $fullName);
+
                 return "\"$fullName\" <$address>";
             }
             $fullName = preg_replace('/(?<!\\\)"/', '\\\\\\\\\"', $fullName);
+
             return '"\"'.$fullName.'\""'." <$address>";
         }
 

--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -95,17 +95,22 @@ class MessageBuilder
      *
      * @return string
      */
-    protected function parseAddress($address, $variables)
+    protected function parseAddress($address, $variables, $nonRecipient = false)
     {
         if (!is_array($variables)) {
             return $address;
         }
         $fullName = $this->getFullName($variables);
         if ($fullName != null) {
-            return "'$fullName' <$address>";
-        }
+            if ($nonRecipient === true) {
+                $fullName = preg_replace('/(?<!\\\)"/', '\"', $fullName);
+                return "\"$fullName\" <$address>";
+            }
+            $fullName = preg_replace('/(?<!\\\)"/', '\\\\\\\\\"', $fullName);
+            return '"\"'.$fullName.'\""'." <$address>";
+        }        
 
-        return $address;
+        return $address;      
     }
 
     /**
@@ -113,9 +118,9 @@ class MessageBuilder
      * @param string $address
      * @param array  $variables
      */
-    protected function addRecipient($headerName, $address, $variables)
+    protected function addRecipient($headerName, $address, $variables, $nonRecipient = false)
     {
-        $compiledAddress = $this->parseAddress($address, $variables);
+        $compiledAddress = $this->parseAddress($address, $variables, $nonRecipient);
 
         if (isset($this->message[$headerName])) {
             array_push($this->message[$headerName], $compiledAddress);
@@ -202,7 +207,7 @@ class MessageBuilder
     {
         $variables = is_array($variables) ? $variables : [];
 
-        $this->addRecipient('from', $address, $variables);
+        $this->addRecipient('from', $address, $variables, true);
 
         return $this->message['from'];
     }
@@ -217,7 +222,7 @@ class MessageBuilder
     {
         $variables = is_array($variables) ? $variables : [];
 
-        $this->addRecipient('h:reply-to', $address, $variables);
+        $this->addRecipient('h:reply-to', $address, $variables, true);
 
         return $this->message['h:reply-to'];
     }


### PR DESCRIPTION
I ran into several issues with quoting of recipients when using MessageBuilder/BatchMessage to send out emails.  

1. Commas require quoting of the display name, otherwise my mail server splits this into several addresses (e.g. lastName@server.domain and firstName <email> instead of "lastName, firstName" <email>).
2. Double-quotes need to be escaped with a backslash inside the display name (unless they're already escaped... but this change probably breaks if someone means to have a literal \").

Reply-To and From addresses need far fewer backslashes for escaping than do To addresses (at least using MessageBuilder/BatchMessage).  I'm not really sure why there is a difference.  I also just started with MailGun this week, but I thought I'd throw up what got me working at the moment.

Hope it helps someone.