### PR TITLE
Avoid fatal error when deserializing unauthorized requests

### DIFF
--- a/src/Mailgun/Api/HttpApi.php
+++ b/src/Mailgun/Api/HttpApi.php
@@ -12,6 +12,7 @@ namespace Mailgun\Api;
 use Http\Client\Exception as HttplugException;
 use Http\Client\HttpClient;
 use Mailgun\Deserializer\ResponseDeserializer;
+use Mailgun\Exception\HttpClientException;
 use Mailgun\Exception\HttpServerException;
 use Mailgun\RequestBuilder;
 use Mailgun\Resource\Api\ErrorResponse;
@@ -59,14 +60,18 @@ abstract class HttpApi
      * @param ResponseInterface $response
      * @param string            $className
      *
+     * @throws HttpClientException
+     *
      * @return object $class
      */
     protected function safeDeserialize(ResponseInterface $response, $className)
     {
-        if ($response->getStatusCode() !== 200) {
-            return $this->deserializer->deserialize($response, ErrorResponse::class);
-        } else {
+        if ($response->getStatusCode() === 200) {
             return $this->deserializer->deserialize($response, $className);
+        } elseif ($response->getStatusCode() === 401) {
+            throw HttpClientException::unauthorized();
+        } else {
+            return $this->deserializer->deserialize($response, ErrorResponse::class);
         }
     }
 


### PR DESCRIPTION
In some cases, the API returns a response without any content (e.g. when supplying an invalid key).

Example:
```php
$mailgun = new Mailgun\Mailgun('invalidkey');
$mailgun->routes()->index(); // throws error/exception
```

In such cases, a fatal error was thrown because `null` was passed to `ErrorResponse::create()` (PHP 5.6) or an exception was thrown when the empty body was decoded ([PHP >7.0](https://3v4l.org/IalIO)).

It might be necessary to include a similar fix for `ArrayDeserializer` as well.