### PR TITLE
Fix integration tests for domain API

### DIFF
--- a/src/Mailgun/Api/HttpApi.php
+++ b/src/Mailgun/Api/HttpApi.php
@@ -129,18 +129,16 @@ abstract class HttpApi
     }
 
     /**
-     * Send a POST request with JSON-encoded parameters.
+     * Send a POST request with parameters.
      *
      * @param string $path           Request path
-     * @param array  $parameters     POST parameters to be JSON encoded
+     * @param array  $parameters     POST parameters
      * @param array  $requestHeaders Request headers
      *
      * @return ResponseInterface
      */
     protected function httpPost($path, array $parameters = [], array $requestHeaders = [])
     {
-        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
-
         return $this->httpPostRaw($path, $this->createRequestBody($parameters), $requestHeaders);
     }
 
@@ -167,18 +165,16 @@ abstract class HttpApi
     }
 
     /**
-     * Send a PUT request with JSON-encoded parameters.
+     * Send a PUT request.
      *
      * @param string $path           Request path
-     * @param array  $parameters     POST parameters to be JSON encoded
+     * @param array  $parameters     PUT parameters
      * @param array  $requestHeaders Request headers
      *
      * @return ResponseInterface
      */
     protected function httpPut($path, array $parameters = [], array $requestHeaders = [])
     {
-        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
-
         try {
             $response = $this->httpClient->sendRequest(
                 $this->requestBuilder->create('PUT', $path, $requestHeaders, $this->createRequestBody($parameters))
@@ -191,18 +187,16 @@ abstract class HttpApi
     }
 
     /**
-     * Send a DELETE request with JSON-encoded parameters.
+     * Send a DELETE request.
      *
      * @param string $path           Request path
-     * @param array  $parameters     POST parameters to be JSON encoded
+     * @param array  $parameters     DELETE parameters
      * @param array  $requestHeaders Request headers
      *
      * @return ResponseInterface
      */
     protected function httpDelete($path, array $parameters = [], array $requestHeaders = [])
     {
-        $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
-
         try {
             $response = $this->httpClient->sendRequest(
                 $this->requestBuilder->create('DELETE', $path, $requestHeaders, $this->createRequestBody($parameters))
@@ -215,14 +209,27 @@ abstract class HttpApi
     }
 
     /**
-     * Create a JSON encoded version of an array of parameters.
+     * Prepare a set of key-value-pairs to be encoded as multipart/form-data.
      *
      * @param array $parameters Request parameters
      *
-     * @return null|string
+     * @return array
      */
     protected function createRequestBody(array $parameters)
     {
-        return (count($parameters) === 0) ? null : http_build_query($parameters);
+        $resources = [];
+        foreach ($parameters as $key => $values) {
+            if (!is_array($values)) {
+                $values = [$values];
+            }
+            foreach ($values as $value) {
+                $resources[] = [
+                    'name' => $key,
+                    'content' => $value,
+                ];
+            }
+        }
+
+        return $resources;
     }
 }

--- a/tests/Integration/DomainApiTest.php
+++ b/tests/Integration/DomainApiTest.php
@@ -10,7 +10,6 @@
 namespace Mailgun\Tests\Integration;
 
 use Mailgun\Api\Domain;
-use Mailgun\Model\ErrorResponse;
 use Mailgun\Model\Domain\CreateCredentialResponse;
 use Mailgun\Model\Domain\DeleteCredentialResponse;
 use Mailgun\Model\Domain\DeleteResponse;
@@ -70,15 +69,15 @@ class DomainApiTest extends TestCase
 
     /**
      * Performs `DELETE /v3/domains/<domain>` on a non-existent domain.
+     *
+     * @expectedException \Mailgun\Exception\HttpClientException
+     * @expectedExceptionCode 404
      */
     public function testRemoveDomainNoExist()
     {
         $mg = $this->getMailgunClient();
 
-        $ret = $mg->domains()->delete('example.notareal.tld');
-        $this->assertNotNull($ret);
-        $this->assertInstanceOf(DeleteResponse::class, $ret);
-        $this->assertEquals('Domain not found', $ret->getMessage());
+        $mg->domains()->delete('example.notareal.tld');
     }
 
     /**
@@ -104,20 +103,20 @@ class DomainApiTest extends TestCase
     /**
      * Performs `POST /v3/domains` to attempt to create a domain with duplicate
      * values.
+     *
+     * @expectedException \Mailgun\Exception\HttpClientException
+     * @expectedExceptionCode 400
      */
     public function testDomainCreateDuplicateValues()
     {
         $mg = $this->getMailgunClient();
 
-        $domain = $mg->domains()->create(
+        $mg->domains()->create(
             'example.notareal.tld',     // domain name
             'exampleOrgSmtpPassword12', // smtp password
             'tag',                      // default spam action
             false                       // wildcard domain?
         );
-        $this->assertNotNull($domain);
-        $this->assertInstanceOf(ErrorResponse::class, $domain);
-        $this->assertEquals('This domain name is already taken', $domain->getMessage());
     }
 
     /**
@@ -214,15 +213,15 @@ class DomainApiTest extends TestCase
 
     /**
      * Performs `GET /v3/domains/<domain>/credentials` on a non-existent domain.
+     *
+     * @expectedException \Mailgun\Exception\HttpClientException
+     * @expectedExceptionCode 404
      */
     public function testListCredentialsBadDomain()
     {
         $mg = $this->getMailgunClient();
 
-        $ret = $mg->domains()->credentials('mailgun.org');
-        $this->assertNotNull($ret);
-        $this->assertInstanceOf(ErrorResponse::class, $ret);
-        $this->assertEquals('Domain not found: mailgun.org', $ret->getMessage());
+        $mg->domains()->credentials('mailgun.org');
     }
 
     /**
@@ -306,6 +305,9 @@ class DomainApiTest extends TestCase
     /**
      * Performs `DELETE /v3/domains/<domain>/credentials/<login>` to remove an invalid
      * credential pair from a domain.
+     *
+     * @expectedException \Mailgun\Exception\HttpClientException
+     * @expectedExceptionCode 404
      */
     public function testRemoveCredentialNoExist()
     {
@@ -313,13 +315,10 @@ class DomainApiTest extends TestCase
 
         $mg = $this->getMailgunClient();
 
-        $ret = $mg->domains()->deleteCredential(
+        $mg->domains()->deleteCredential(
             $this->testDomain,
             $login
         );
-        $this->assertNotNull($ret);
-        $this->assertInstanceOf(DeleteCredentialResponse::class, $ret);
-        $this->assertEquals('Credentials not found', $ret->getMessage());
     }
 
     /**


### PR DESCRIPTION
The integration tests for the Domain API were failing because non-GET requests did not work properly and in cases when an error occured, a generic `ErrorResponse` was actually returned.