### PR TITLE
[RFC] Re-enable integration tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,6 @@
     <testsuites>
         <testsuite name="all">
             <directory>tests</directory>
-            <exclude>tests/Integration</exclude>
         </testsuite>
 
         <testsuite name="unit">


### PR DESCRIPTION
To ensure that the integration tests don't fall behind the current development, it might make sense to enable them again. The testsuite only covers a small subset of the whole API so updating it won't cause much work and ensures that this library is working (and continues to).