### PR TITLE
fix: named addresses must be surrounded by double quotes

### DIFF
--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -102,7 +102,7 @@ class MessageBuilder
         }
         $fullName = $this->getFullName($variables);
         if ($fullName != null) {
-            return "'$fullName' <$address>";
+            return '"' . $fullName . '" <' . $address . '>';
         }
 
         return $address;

--- a/src/Mailgun/Messages/MessageBuilder.php
+++ b/src/Mailgun/Messages/MessageBuilder.php
@@ -102,7 +102,7 @@ class MessageBuilder
         }
         $fullName = $this->getFullName($variables);
         if ($fullName != null) {
-            return '"' . $fullName . '" <' . $address . '>';
+            return sprintf('"%s" <%s>', $fullName, $address);
         }
 
         return $address;

--- a/tests/Messages/BatchMessageTest.php
+++ b/tests/Messages/BatchMessageTest.php
@@ -32,7 +32,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addToRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['to' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['to' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
 
         $reflectionClass = new \ReflectionClass(get_class($message));
         $property = $reflectionClass->getProperty('counters');
@@ -60,7 +60,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addToRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['to' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['to' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
 
         $reflectionClass = new \ReflectionClass(get_class($message));
         $property = $reflectionClass->getProperty('batchRecipientAttributes');
@@ -75,7 +75,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addCcRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['cc' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['cc' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
 
         $reflectionClass = new \ReflectionClass(get_class($message));
         $property = $reflectionClass->getProperty('batchRecipientAttributes');
@@ -90,7 +90,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addBccRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['bcc' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['bcc' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
 
         $reflectionClass = new \ReflectionClass(get_class($message));
         $property = $reflectionClass->getProperty('batchRecipientAttributes');

--- a/tests/Messages/MessageBuilderTest.php
+++ b/tests/Messages/MessageBuilderTest.php
@@ -48,7 +48,7 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->MessageBuilder();
         $message->addToRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['to' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['to' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
     }
 
     public function testAddCcRecipient()
@@ -56,7 +56,7 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->MessageBuilder();
         $message->addCcRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['cc' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['cc' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
     }
 
     public function testAddBccRecipient()
@@ -64,7 +64,7 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->MessageBuilder();
         $message->addBccRecipient('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['bcc' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['bcc' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
     }
 
     public function testToRecipientCount()
@@ -108,7 +108,7 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase
         $message = $this->client->MessageBuilder();
         $message->setFromAddress('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['from' => ["'Test User' <test@samples.mailgun.org>"]], $messageObj);
+        $this->assertEquals(['from' => ['"Test User" <test@samples.mailgun.org>']], $messageObj);
     }
 
     public function testSetReplyTo()
@@ -117,7 +117,7 @@ class MessageBuilderTest extends \Mailgun\Tests\MailgunTestCase
         $message->setReplyToAddress('overwritten@samples.mailgun.org');
         $message->setReplyToAddress('test@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
         $messageObj = $message->getMessage();
-        $this->assertEquals(['h:reply-to' => "'Test User' <test@samples.mailgun.org>"], $messageObj);
+        $this->assertEquals(['h:reply-to' => '"Test User" <test@samples.mailgun.org>'], $messageObj);
     }
 
     public function testSetSubject()


### PR DESCRIPTION
Due to your recent API update, named addresses with special chars (like parentheses) are now rejected if they are surrounded by simple quotes
They must be surrounded by double quotes

'Whoever (SomeCompany)' <some@address.com> is no longer valid and will be rejected by your API
"Whoever (SomeCompany)" <some@address.com> is valid and will be OK