### PR TITLE
Fix batch message undefined property error

### DIFF
--- a/src/Mailgun/Messages/BatchMessage.php
+++ b/src/Mailgun/Messages/BatchMessage.php
@@ -132,7 +132,10 @@ class BatchMessage extends MessageBuilder
             $this->counters['recipients']['cc'] = 0;
             $this->counters['recipients']['bcc'] = 0;
             unset($this->message['to']);
-            array_push($this->messageIds, $response->http_response_body->id);
+
+            if (isset($response->http_response_body->id)) {
+                array_push($this->messageIds, $response->http_response_body->id);
+            }
         }
     }
 

--- a/tests/Messages/BatchMessageTest.php
+++ b/tests/Messages/BatchMessageTest.php
@@ -10,6 +10,7 @@
 namespace Mailgun\Tests\Messages;
 
 use Mailgun\Tests\Mock\Mailgun;
+use Mailgun\Tests\Mock\PostBinMailgun;
 
 class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
 {
@@ -147,7 +148,7 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $this->assertEquals(1, $propertyValue['test-user@samples.mailgun.org']['id']);
     }
 
-    public function testgetMessageIds()
+    public function testGetMessageIds()
     {
         $message = $this->client->BatchMessage($this->sampleDomain);
         $message->addToRecipient('test-user@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
@@ -157,6 +158,19 @@ class BatchMessageTest extends \Mailgun\Tests\MailgunTestCase
         $message->finalize();
 
         $this->assertEquals(['1234'], $message->getMessageIds());
+    }
+
+    public function testGetMessageIdsWhenIdMissingInResponse()
+    {
+        $client = new PostBinMailgun('My-Super-Awesome-API-Key');
+        $message = $client->BatchMessage($this->sampleDomain);
+        $message->addToRecipient('test-user@samples.mailgun.org', ['first' => 'Test', 'last' => 'User']);
+        $message->setFromAddress('samples@mailgun.org', ['first' => 'Test', 'last' => 'User']);
+        $message->setSubject('This is the subject of the message!');
+        $message->setTextBody('This is the text body of the message!');
+        $message->finalize();
+
+        $this->assertEquals([], $message->getMessageIds());
     }
 
     public function testInvalidMissingRequiredMIMEParametersExceptionGetsFlungNoFrom()

--- a/tests/Mock/Connection/PostBinBroker.php
+++ b/tests/Mock/Connection/PostBinBroker.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Copyright (C) 2013-2016 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+namespace Mailgun\Tests\Mock\Connection;
+
+class PostBinBroker extends TestBroker
+{
+    protected $responseData = '{"message": "Some JSON Response Data"}';
+}

--- a/tests/Mock/Connection/TestBroker.php
+++ b/tests/Mock/Connection/TestBroker.php
@@ -21,6 +21,8 @@ class TestBroker extends RestClient
 
     protected $apiEndpoint;
 
+    protected $responseData = '{"message": "Some JSON Response Data", "id": "1234"}';
+
     public function __construct($apiKey = null, $apiHost = 'api.mailgun.net', $apiVersion = 'v3')
     {
         $this->apiKey = $apiKey;
@@ -52,7 +54,7 @@ class TestBroker extends RestClient
         if ($httpResponseCode === 200) {
             $result = new \stdClass();
             $result->http_response_body = new \stdClass();
-            $jsonResponseData = json_decode('{"message": "Some JSON Response Data", "id": "1234"}');
+            $jsonResponseData = json_decode($this->responseData);
             foreach ($jsonResponseData as $key => $value) {
                 $result->http_response_body->$key = $value;
             }

--- a/tests/Mock/PostBinMailgun.php
+++ b/tests/Mock/PostBinMailgun.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (C) 2013-2016 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+namespace Mailgun\Tests\Mock;
+
+use Mailgun\Tests\Mock\Connection\PostBinBroker;
+
+class PostBinMailgun extends Mailgun
+{
+    public function __construct($apiKey = null, $apiEndpoint = 'api.mailgun.net', $apiVersion = 'v3')
+    {
+        $this->restClient = new PostBinBroker($apiKey, $apiEndpoint, $apiVersion);
+    }
+}


### PR DESCRIPTION
While testing Batch Messages against Postbin I got an error of "Undefined property: stdClass::$id" because post bin doesn't return an id in it's response message. So I wrote this PR to get Batch Messages to check for id's in responses.