### PR TITLE
Expose response code from HttpClientException

### DIFF
--- a/src/Mailgun/Exception/HttpClientException.php
+++ b/src/Mailgun/Exception/HttpClientException.php
@@ -28,6 +28,11 @@ final class HttpClientException extends \RuntimeException implements Exception
     private $responseBody;
 
     /**
+     * @var int
+     */
+    private $responseCode;
+
+    /**
      * @param string                 $message
      * @param int                    $code
      * @param ResponseInterface|null $response
@@ -38,6 +43,7 @@ final class HttpClientException extends \RuntimeException implements Exception
 
         if ($response) {
             $this->response = $response;
+            $this->responseCode = $response->getStatusCode();
             $body = $response->getBody()->__toString();
             if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
                 $this->responseBody['message'] = $body;
@@ -81,5 +87,13 @@ final class HttpClientException extends \RuntimeException implements Exception
     public function getResponseBody()
     {
         return $this->responseBody;
+    }
+
+    /**
+     * @return int
+     */
+    public function getResponseCode()
+    {
+        return $this->responseCode;
     }
 }

--- a/src/Mailgun/Exception/HttpServerException.php
+++ b/src/Mailgun/Exception/HttpServerException.php
@@ -18,12 +18,12 @@ final class HttpServerException extends \RuntimeException implements Exception
 {
     public static function serverError($httpStatus = 500)
     {
-        return new self('An unexpected error occurred at Mailgun\'s servers. Try again later and contact support of the error sill exists.', $httpStatus);
+        return new self('An unexpected error occurred at Mailgun\'s servers. Try again later and contact support if the error sill exists.', $httpStatus);
     }
 
     public static function networkError(\Exception $previous)
     {
-        return new self('Mailgun\'s servers was unreachable.', 0, $previous);
+        return new self('Mailgun\'s servers are currently unreachable.', 0, $previous);
     }
 
     public static function unknownHttpResponseCode($code)


### PR DESCRIPTION
A complaint I received is that it was no longer easy to determine, for example, if a bounce a user is trying to `GET` is not found or if another API error occurred. This should help to ease that issue.