### PR TITLE
Fix for deprecation message for `sendMessage()`

### DIFF
--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -127,7 +127,7 @@ class Mailgun
      *
      * @return \stdClass
      *
-     * @deprecated Use Mailgun->message() instead. Will be removed in 3.0
+     * @deprecated Use Mailgun->messages()->send() instead. Will be removed in 3.0
      */
     public function sendMessage($workingDomain, $postData, $postFiles = [])
     {


### PR DESCRIPTION
The `sendMessage()` method will be replaced by `Mailgun->messages()->send()` see issue #382 