### PR TITLE
Fixed stats retrieval

### DIFF
--- a/src/Mailgun/Model/Stats/TotalResponse.php
+++ b/src/Mailgun/Model/Stats/TotalResponse.php
@@ -58,7 +58,7 @@ final class TotalResponse implements ApiResponse
     public static function create(array $data)
     {
         $stats = [];
-        if (isset($data['status'])) {
+        if (isset($data['stats'])) {
             foreach ($data['stats'] as $s) {
                 $stats[] = TotalResponseItem::create($s);
             }

--- a/src/Mailgun/Model/Stats/TotalResponseItem.php
+++ b/src/Mailgun/Model/Stats/TotalResponseItem.php
@@ -43,9 +43,9 @@ class TotalResponseItem
     {
         return new self(
             isset($data['time']) ? new \DateTime($data['time']) : null,
-            isset($data['accepted']) ? $data['accepted'] : null,
-            isset($data['delivered']) ? $data['delivered'] : null,
-            isset($data['failed']) ? $data['failed'] : null
+            isset($data['accepted']) ? $data['accepted'] : [],
+            isset($data['delivered']) ? $data['delivered'] : [],
+            isset($data['failed']) ? $data['failed'] : []
         );
     }
 

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -10,6 +10,9 @@
 namespace Mailgun\Tests\Api;
 
 use GuzzleHttp\Psr7\Response;
+use Mailgun\Hydrator\ModelHydrator;
+use Mailgun\Model\Stats\TotalResponse;
+use Mailgun\Model\Stats\TotalResponseItem;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -21,19 +24,22 @@ class StatsTest extends TestCase
         return 'Mailgun\Api\Stats';
     }
 
-    public function testTotal()
+    /**
+     * @dataProvider totalProvider
+     */
+    public function testTotal($queryParameters, $responseData)
     {
-        $data = [
-            'foo' => 'bar',
-        ];
-
-        $api = $this->getApiMock();
+        $api = $this->getApiMock(null, null, new ModelHydrator());
         $api->expects($this->once())
             ->method('httpGet')
-            ->with('/v3/domain/stats/total', $data)
-            ->willReturn(new Response());
+            ->with('/v3/domain/stats/total', $queryParameters)
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], \json_encode($responseData)));
 
-        $api->total('domain', $data);
+        $total = $api->total('domain', $queryParameters);
+
+        $this->assertInstanceOf(TotalResponse::class, $total);
+        $this->assertCount(count($responseData['stats']), $total->getStats());
+        $this->assertContainsOnlyInstancesOf(TotalResponseItem::class, $total->getStats());
     }
 
     /**
@@ -68,5 +74,79 @@ class StatsTest extends TestCase
         $api = $this->getApiMock();
 
         $api->all('');
+    }
+
+    public function totalProvider()
+    {
+        return [
+            'accepted events' => [
+                'queryParameters' => [
+                    'event' => 'accepted',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'accepted' => [
+                            'outgoing' => 10,
+                            'incoming' => 5,
+                            'total' => 15,
+                        ],
+                    ],
+                ]),
+            ],
+            'failed events' => [
+                'queryParameters' => [
+                    'event' => 'failed',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'failed' => [
+                            'permanent' => [
+                                'bounce' => 4,
+                                'delayed-bounce' => 1,
+                                'suppress-bounce' => 1,
+                                'suppress-unsubscribe' => 2,
+                                'suppress-complaint' => 3,
+                                'total' => 10,
+                            ],
+                            'temporary' => [
+                                'espblock' => 1,
+                            ],
+                        ],
+                    ],
+                ]),
+            ],
+            'delivered events' => [
+                'queryParameters' => [
+                    'event' => 'delivered',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'delivered' => [
+                            'smtp' => 15,
+                            'http' => 5,
+                            'total' => 20,
+                        ],
+                    ],
+                ]),
+            ],
+        ];
+    }
+
+    private function generateTotalResponsePayload(array $stats, $start = '-7 days', $end = 'now', $resolution = 'day')
+    {
+        return [
+            'end' => $this->formatDate($end),
+            'resolution' => $resolution,
+            'start' => $this->formatDate($start),
+            'stats' => $stats,
+        ];
+    }
+
+    private function formatDate($time = 'now')
+    {
+        return (new \DateTime($time, new \DateTimeZone('UTC')))->format('D, d M Y H:i:s T');
     }
 }

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -38,7 +38,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected $testDomain;
 
-    public function __construct()
+    protected function setUp()
     {
         $this->apiPrivKey = getenv('MAILGUN_PRIV_KEY');
         $this->apiPubKey = getenv('MAILGUN_PUB_KEY');
@@ -47,22 +47,28 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     abstract protected function getApiClass();
 
-    protected function getApiMock()
+    protected function getApiMock($httpClient = null, $requestClient = null, $hydrator = null)
     {
-        $httpClient = $this->getMockBuilder('Http\Client\HttpClient')
-            ->setMethods(['sendRequest'])
-            ->getMock();
-        $httpClient
-            ->expects($this->any())
-            ->method('sendRequest');
+        if (null === $httpClient) {
+            $httpClient = $this->getMockBuilder('Http\Client\HttpClient')
+                ->setMethods(['sendRequest'])
+                ->getMock();
+            $httpClient
+                ->expects($this->any())
+                ->method('sendRequest');
+        }
 
-        $requestClient = $this->getMockBuilder('Mailgun\RequestBuilder')
-            ->setMethods(['create'])
-            ->getMock();
+        if (null === $requestClient) {
+            $requestClient = $this->getMockBuilder('Mailgun\RequestBuilder')
+                ->setMethods(['create'])
+                ->getMock();
+        }
 
-        $hydrator = $this->getMockBuilder('Mailgun\Hydrator\Hydrator')
-            ->setMethods(['hydrate'])
-            ->getMock();
+        if (null === $hydrator) {
+            $hydrator = $this->getMockBuilder('Mailgun\Hydrator\Hydrator')
+                ->setMethods(['hydrate'])
+                ->getMock();
+        }
 
         return $this->getMockBuilder($this->getApiClass())
             ->setMethods(['httpGet', 'httpPost', 'httpPostRaw', 'httpDelete', 'httpPut'])


### PR DESCRIPTION
Currently when using the `stats->total()` method, it always returns an empty array for stats.

- There was an issue in the code, with a wrong isset check.
- There was a second issue on `TotalResponseItem` as some constructor parameters are typed as array but in some case, the null value is passed instead.


There is also a third issue (I don't take time to resolve as it's more difficult), as we can't specified a list of stats events to retrieve from the api as the query is not formatted as expected, which makes the method only usable with one event, not several.

Mailgun expects `/v3/xxx/stats/total?duration=100d&event=delivered&event=failed`

Instead the mailgun-php library formats it this way: `/v3/xxx/stats/total?duration=100d&event%5B0%5D=delivered&event%5B1%5D=failed`

As fixing this requires updating the `httpGet` method from the `HttpApi` class and not using the `http_build_query` function, I don't know what is the best way to fix it.

There is also a fourth issue (that could probably be solved here too, just need to confirm if wanted), as  currently we can only retrieve the failed, delivered and accepted stats event, but there are a lot more of events, see http://mailgun-documentation.readthedocs.io/en/latest/api-stats.html#event-types