### PR TITLE
Update README.md with setting API version to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ $mg->messages()->send('example.com', [
 ```
 ### Additional Info
 
+In order to delete bounces from Mailgun you will need to use v3. The API endpoint version by default is set to v2 which is not compatible with some bounces and unsubscribe endpoints (example: <yourdomainname>/bounces/<emailaddress> does not work with v2). You can set the version to v3 by adding $mg->setApiVersion('v3'); directly after $mg = Mailgun::create('key-example');
+
 For usage examples on each API endpoint, head over to our official documentation 
 pages. 
 


### PR DESCRIPTION
Certain endpoints for bounces and unsubscribes do not work with the v2 endpoint which the RestClient.php file still uses by default. It appears as though email sending still uses v2 by default too.

I updated the README to explain a workaround for this by setting the API version in the code using $mg->setApiVersion('v3');

A better solution imo would be to update the code to use v3 by default but I am not sure if that would break other things. Please let me know if there is a better solution to this.