### PR TITLE
Require styleci brigde in require dev composer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__.'/vendor/autoload.php';
+
 /*
  * In order to make it work, fabpot/php-cs-fixer and sllh/php-cs-fixer-styleci-bridge must be installed globally
  * with composer.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.8",
         "php-http/guzzle6-adapter": "^1.0",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.4",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.8",
         "php-http/guzzle6-adapter": "^1.0",
-        "guzzlehttp/psr7": "^1.4",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
+        "guzzlehttp/psr7": "^1.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
According to https://github.com/mailgun/mailgun-php/blob/master/.php_cs it is needed to be installed to run php-cs-fixer, so adding as require dev only with:

`composer require --dev sllh/php-cs-fixer-styleci-bridge`

