### PR TITLE
Implement getId(), setAddress() and add doc

### DIFF
--- a/src/Mailgun/Model/Suppression/Unsubscribe/Unsubscribe.php
+++ b/src/Mailgun/Model/Suppression/Unsubscribe/Unsubscribe.php
@@ -15,31 +15,54 @@ namespace Mailgun\Model\Suppression\Unsubscribe;
 class Unsubscribe
 {
     /**
+     * The unsubscribe event identifier
+     * 
      * @var string
      */
-    private $address;
-
+    private $id = NULL;
+    
     /**
+     * The unsubscribe email address
      * @var string
      */
-    private $tag;
+    private $address = NULL;
 
     /**
+     * Tag to unsubscribe from, use * to unsubscribe address from domain
+     * 
+     * Note: If NULL the value means * (all for a domain)
+     * 
+     * @var string
+     */
+    private $tag = NULL;
+
+    /**
+     * The creation date for the event
+     * 
      * @var \DateTime
      */
-    private $createdAt;
+    private $createdAt = NULL;
 
     /**
      * @param string $address
      */
-    private function __construct($address)
+    private function __construct($address = NULL)
     {
         $this->address = $address;
         $this->createdAt = new \DateTime();
     }
 
     /**
-     * @param array $data
+     * Create a Unsubscribe object based in info provided in $data array
+     * 
+     * Fields allowed:
+     * 
+     * - id: The unsubscribe event identifier
+     * - address: The unsubscribe email address
+     * - tag: Tag to unsubscribe (use * or NULL to unsubscribe address from domain)
+     * - created_at: The creation date for the event
+     * 
+     * @param array $data the info provided
      *
      * @return Unsubscribe
      */
@@ -47,9 +70,14 @@ class Unsubscribe
     {
         $unsubscribe = new self($data['address']);
 
+        if (isset($data['id'])) {
+            $unsubscribe->setId($data['id']);
+        }
+        
         if (isset($data['tag'])) {
             $unsubscribe->setTag($data['tag']);
         }
+        
         if (isset($data['created_at'])) {
             $unsubscribe->setCreatedAt(new \DateTime($data['created_at']));
         }
@@ -57,7 +85,31 @@ class Unsubscribe
         return $unsubscribe;
     }
 
+	/**
+	 * Get the event identifier
+	 * 
+     * @return string The event identifier
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+    
     /**
+     * Set the event identifier 
+     * 
+     * @param string $id The event identifier
+     */
+    private function setId($id = NULL)
+    {
+        $this->id = $id;
+        
+        return $this;
+    }
+    
+    /**
+     * Get the email address unsubscribed
+     * 
      * @return string
      */
     public function getAddress()
@@ -66,6 +118,24 @@ class Unsubscribe
     }
 
     /**
+     * Set the email address unsubscribed
+     * 
+     * @param string $address The email address unsubscribed
+     */
+    private function setAddress($address = NULL)
+    {
+        $this->address = $address;
+        
+        return $this;
+    }
+    
+    /**
+     * Get the tag 
+     * 
+     * Note: * means all unsubscribe address from domain
+     * 
+     * If NULL the value means * (all for a domain)
+     * 
      * @return string
      */
     public function getTag()
@@ -74,14 +144,24 @@ class Unsubscribe
     }
 
     /**
-     * @param string $tag
+     * Set the tag 
+     * 
+     * Note: * means all unsubscribe address from domain
+     * 
+     * If NULL the value means * (all for a domain)
+     * 
+     * @param string $tag The tag
      */
-    private function setTag($tag)
+    private function setTag($tag = NULL)
     {
         $this->tag = $tag;
+        
+        return $this;
     }
 
     /**
+     * The creation date for the event
+     * 
      * @return \DateTime
      */
     public function getCreatedAt()
@@ -90,10 +170,14 @@ class Unsubscribe
     }
 
     /**
-     * @param \DateTime $createdAt
+     * The creation date for the event
+     * 
+     * @param \DateTime $createdAt The creation date for the event
      */
-    private function setCreatedAt(\DateTime $createdAt)
+    private function setCreatedAt(\DateTime $createdAt = NULL)
     {
         $this->createdAt = $createdAt;
+        
+        return $this;
     }
 }


### PR DESCRIPTION
This should cover part 4 of issue #390 

I add doc in general and implement getId() and setAddress(). Also some useful changes as return $this in set methods that allow chain the setters for example:

```
$unsubscribe = (new Unsubscribe('someemail@example.com'))
                         ->setTag('my_tag')
                         ->setId('000000001')
                         ->setCreationDate(\Datetime('NOW'));
```
