### PR TITLE
Correction of the "Readable filename" array record key

### DIFF
--- a/src/Mailgun/Connection/RestClient.php
+++ b/src/Mailgun/Connection/RestClient.php
@@ -298,7 +298,7 @@ class RestClient
         } else {
             // Backward compatibility code
             if (is_array($filePath) && isset($filePath['filePath'])) {
-                $filename = $filePath['remoteName'];
+                $filename = $filePath['filename'];
                 $filePath = $filePath['filePath'];
             }
 


### PR DESCRIPTION
Guidelines described in docs/attachment.md in section "From file path" that "filename" array record Id should be used as an ID for readable name of attached file, however in file "/src/Mailgun/Connection/RestClient.php", specifically in method "prepareFile" where processing of attachments is in fact implemented, is "filename" information in this case read out from the array record with id "remoteName".