### PR TITLE
Mailgun #417 Interfaces names should end with "Interface"

### DIFF
--- a/src/Mailgun/Api/HttpApi.php
+++ b/src/Mailgun/Api/HttpApi.php
@@ -12,7 +12,7 @@ namespace Mailgun\Api;
 use Http\Client\Exception as HttplugException;
 use Http\Client\HttpClient;
 use Mailgun\Exception\UnknownErrorException;
-use Mailgun\Hydrator\Hydrator;
+use Mailgun\Hydrator\HydratorInterface;
 use Mailgun\Hydrator\NoopHydrator;
 use Mailgun\Exception\HttpClientException;
 use Mailgun\Exception\HttpServerException;
@@ -32,7 +32,7 @@ abstract class HttpApi
     private $httpClient;
 
     /**
-     * @var Hydrator
+     * @var HydratorInterface
      */
     protected $hydrator;
 
@@ -44,9 +44,9 @@ abstract class HttpApi
     /**
      * @param HttpClient     $httpClient
      * @param RequestBuilder $requestBuilder
-     * @param Hydrator       $hydrator
+     * @param HydratorInterface       $hydrator
      */
-    public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator)
+    public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, HydratorInterface $hydrator)
     {
         $this->httpClient = $httpClient;
         $this->requestBuilder = $requestBuilder;

--- a/src/Mailgun/Api/HttpApi.php
+++ b/src/Mailgun/Api/HttpApi.php
@@ -42,9 +42,9 @@ abstract class HttpApi
     protected $requestBuilder;
 
     /**
-     * @param HttpClient     $httpClient
-     * @param RequestBuilder $requestBuilder
-     * @param HydratorInterface       $hydrator
+     * @param HttpClient        $httpClient
+     * @param RequestBuilder    $requestBuilder
+     * @param HydratorInterface $hydrator
      */
     public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, HydratorInterface $hydrator)
     {

--- a/src/Mailgun/Api/Pagination.php
+++ b/src/Mailgun/Api/Pagination.php
@@ -10,7 +10,7 @@
 namespace Mailgun\Api;
 
 use Mailgun\Assert;
-use Mailgun\Model\PagingProvider;
+use Mailgun\Model\PagingProviderInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -23,41 +23,41 @@ trait Pagination
     abstract protected function hydrateResponse(ResponseInterface $response, $className);
 
     /**
-     * @param PagingProvider $response
+     * @param PagingProviderInterface $response
      *
-     * @return PagingProvider|null
+     * @return PagingProviderInterface|null
      */
-    public function nextPage(PagingProvider $response)
+    public function nextPage(PagingProviderInterface $response)
     {
         return $this->getPaginationUrl($response->getNextUrl(), get_class($response));
     }
 
     /**
-     * @param PagingProvider $response
+     * @param PagingProviderInterface $response
      *
-     * @return PagingProvider|null
+     * @return PagingProviderInterface|null
      */
-    public function previousPage(PagingProvider $response)
+    public function previousPage(PagingProviderInterface $response)
     {
         return $this->getPaginationUrl($response->getPreviousUrl(), get_class($response));
     }
 
     /**
-     * @param PagingProvider $response
+     * @param PagingProviderInterface $response
      *
-     * @return PagingProvider|null
+     * @return PagingProviderInterface|null
      */
-    public function firstPage(PagingProvider $response)
+    public function firstPage(PagingProviderInterface $response)
     {
         return $this->getPaginationUrl($response->getFirstUrl(), get_class($response));
     }
 
     /**
-     * @param PagingProvider $response
+     * @param PagingProviderInterface $response
      *
-     * @return PagingProvider|null
+     * @return PagingProviderInterface|null
      */
-    public function lastPage(PagingProvider $response)
+    public function lastPage(PagingProviderInterface $response)
     {
         return $this->getPaginationUrl($response->getLastUrl(), get_class($response));
     }
@@ -66,7 +66,7 @@ trait Pagination
      * @param string $url
      * @param string $class
      *
-     * @return PagingProvider|null
+     * @return PagingProviderInterface|null
      */
     private function getPaginationUrl($url, $class)
     {

--- a/src/Mailgun/Api/Suppression.php
+++ b/src/Mailgun/Api/Suppression.php
@@ -39,9 +39,9 @@ class Suppression
     private $hydrator;
 
     /**
-     * @param HttpClient     $httpClient
-     * @param RequestBuilder $requestBuilder
-     * @param HydratorInterface       $hydrator
+     * @param HttpClient        $httpClient
+     * @param RequestBuilder    $requestBuilder
+     * @param HydratorInterface $hydrator
      */
     public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, HydratorInterface $hydrator)
     {

--- a/src/Mailgun/Api/Suppression.php
+++ b/src/Mailgun/Api/Suppression.php
@@ -13,7 +13,7 @@ use Http\Client\HttpClient;
 use Mailgun\Api\Suppression\Bounce;
 use Mailgun\Api\Suppression\Complaint;
 use Mailgun\Api\Suppression\Unsubscribe;
-use Mailgun\Hydrator\Hydrator;
+use Mailgun\Hydrator\HydratorInterface;
 use Mailgun\RequestBuilder;
 
 /**
@@ -34,16 +34,16 @@ class Suppression
     private $requestBuilder;
 
     /**
-     * @var Hydrator
+     * @var HydratorInterface
      */
     private $hydrator;
 
     /**
      * @param HttpClient     $httpClient
      * @param RequestBuilder $requestBuilder
-     * @param Hydrator       $hydrator
+     * @param HydratorInterface       $hydrator
      */
-    public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator)
+    public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, HydratorInterface $hydrator)
     {
         $this->httpClient = $httpClient;
         $this->requestBuilder = $requestBuilder;

--- a/src/Mailgun/Api/Webhook.php
+++ b/src/Mailgun/Api/Webhook.php
@@ -11,7 +11,7 @@ namespace Mailgun\Api;
 
 use Http\Client\HttpClient;
 use Mailgun\Assert;
-use Mailgun\Hydrator\Hydrator;
+use Mailgun\Hydrator\HydratorInterface;
 use Mailgun\Model\Webhook\CreateResponse;
 use Mailgun\Model\Webhook\DeleteResponse;
 use Mailgun\Model\Webhook\IndexResponse;
@@ -32,10 +32,10 @@ class Webhook extends HttpApi
     /**
      * @param HttpClient     $httpClient
      * @param RequestBuilder $requestBuilder
-     * @param Hydrator       $hydrator
+     * @param HydratorInterface       $hydrator
      * @param string         $apiKey
      */
-    public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator, $apiKey)
+    public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, HydratorInterface $hydrator, $apiKey)
     {
         parent::__construct($httpClient, $requestBuilder, $hydrator);
         $this->apiKey = $apiKey;

--- a/src/Mailgun/Api/Webhook.php
+++ b/src/Mailgun/Api/Webhook.php
@@ -30,10 +30,10 @@ class Webhook extends HttpApi
     private $apiKey;
 
     /**
-     * @param HttpClient     $httpClient
-     * @param RequestBuilder $requestBuilder
-     * @param HydratorInterface       $hydrator
-     * @param string         $apiKey
+     * @param HttpClient        $httpClient
+     * @param RequestBuilder    $requestBuilder
+     * @param HydratorInterface $hydrator
+     * @param string            $apiKey
      */
     public function __construct(HttpClient $httpClient, RequestBuilder $requestBuilder, HydratorInterface $hydrator, $apiKey)
     {

--- a/src/Mailgun/Hydrator/ArrayHydrator.php
+++ b/src/Mailgun/Hydrator/ArrayHydrator.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class ArrayHydrator implements Hydrator
+final class ArrayHydrator implements HydratorInterface
 {
     /**
      * @param ResponseInterface $response

--- a/src/Mailgun/Hydrator/HydratorInterface.php
+++ b/src/Mailgun/Hydrator/HydratorInterface.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Deserialize a PSR-7 response to something else.
  */
-interface Hydrator
+interface HydratorInterface
 {
     /**
      * @param ResponseInterface $response

--- a/src/Mailgun/Hydrator/ModelHydrator.php
+++ b/src/Mailgun/Hydrator/ModelHydrator.php
@@ -10,7 +10,7 @@
 namespace Mailgun\Hydrator;
 
 use Mailgun\Exception\HydrationException;
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -39,7 +39,7 @@ final class ModelHydrator implements HydratorInterface
             throw new HydrationException(sprintf('Error (%d) when trying to json_decode response', json_last_error()));
         }
 
-        if (is_subclass_of($class, ApiResponse::class)) {
+        if (is_subclass_of($class, ApiResponseInterface::class)) {
             $object = call_user_func($class.'::create', $data);
         } else {
             $object = new $class($data);

--- a/src/Mailgun/Hydrator/ModelHydrator.php
+++ b/src/Mailgun/Hydrator/ModelHydrator.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\ResponseInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class ModelHydrator implements Hydrator
+final class ModelHydrator implements HydratorInterface
 {
     /**
      * @param ResponseInterface $response

--- a/src/Mailgun/Hydrator/NoopHydrator.php
+++ b/src/Mailgun/Hydrator/NoopHydrator.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class NoopHydrator implements Hydrator
+final class NoopHydrator implements HydratorInterface
 {
     /**
      * @param ResponseInterface $response

--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -19,7 +19,7 @@ use Mailgun\Messages\BatchMessage;
 use Mailgun\Messages\Exceptions;
 use Mailgun\Messages\MessageBuilder;
 use Mailgun\Hydrator\ModelHydrator;
-use Mailgun\Hydrator\Hydrator;
+use Mailgun\Hydrator\HydratorInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -45,7 +45,7 @@ class Mailgun
     private $httpClient;
 
     /**
-     * @var Hydrator
+     * @var HydratorInterface
      */
     private $hydrator;
 
@@ -65,7 +65,7 @@ class Mailgun
      * @param string|null         $apiKey
      * @param HttpClient|null     $httpClient
      * @param string              $apiEndpoint
-     * @param Hydrator|null       $hydrator
+     * @param HydratorInterface|null       $hydrator
      * @param RequestBuilder|null $requestBuilder
      *
      * @internal Use Mailgun::configure or Mailgun::create instead.
@@ -74,7 +74,7 @@ class Mailgun
         $apiKey = null, /* Deprecated, will be removed in 3.0 */
         HttpClient $httpClient = null,
         $apiEndpoint = 'api.mailgun.net', /* Deprecated, will be removed in 3.0 */
-        Hydrator $hydrator = null,
+        HydratorInterface $hydrator = null,
         RequestBuilder $requestBuilder = null
     ) {
         $this->apiKey = $apiKey;
@@ -87,14 +87,14 @@ class Mailgun
 
     /**
      * @param HttpClientConfigurator $configurator
-     * @param Hydrator|null          $hydrator
+     * @param HydratorInterface|null          $hydrator
      * @param RequestBuilder|null    $requestBuilder
      *
      * @return Mailgun
      */
     public static function configure(
         HttpClientConfigurator $configurator,
-        Hydrator $hydrator = null,
+        HydratorInterface $hydrator = null,
         RequestBuilder $requestBuilder = null
     ) {
         $httpClient = $configurator->createConfiguredClient();

--- a/src/Mailgun/Mailgun.php
+++ b/src/Mailgun/Mailgun.php
@@ -62,11 +62,11 @@ class Mailgun
     private $responseHistory = null;
 
     /**
-     * @param string|null         $apiKey
-     * @param HttpClient|null     $httpClient
-     * @param string              $apiEndpoint
-     * @param HydratorInterface|null       $hydrator
-     * @param RequestBuilder|null $requestBuilder
+     * @param string|null            $apiKey
+     * @param HttpClient|null        $httpClient
+     * @param string                 $apiEndpoint
+     * @param HydratorInterface|null $hydrator
+     * @param RequestBuilder|null    $requestBuilder
      *
      * @internal Use Mailgun::configure or Mailgun::create instead.
      */
@@ -87,7 +87,7 @@ class Mailgun
 
     /**
      * @param HttpClientConfigurator $configurator
-     * @param HydratorInterface|null          $hydrator
+     * @param HydratorInterface|null $hydrator
      * @param RequestBuilder|null    $requestBuilder
      *
      * @return Mailgun

--- a/src/Mailgun/Model/ApiResponseInterface.php
+++ b/src/Mailgun/Model/ApiResponseInterface.php
@@ -12,7 +12,7 @@ namespace Mailgun\Model;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-interface ApiResponse
+interface ApiResponseInterface
 {
     /**
      * Create an API response object from the HTTP response from the API server.

--- a/src/Mailgun/Model/Domain/AbstractDomainResponse.php
+++ b/src/Mailgun/Model/Domain/AbstractDomainResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class AbstractDomainResponse implements ApiResponse
+abstract class AbstractDomainResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Domain/ConnectionResponse.php
+++ b/src/Mailgun/Model/Domain/ConnectionResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class ConnectionResponse implements ApiResponse
+final class ConnectionResponse implements ApiResponseInterface
 {
     /**
      * @var bool

--- a/src/Mailgun/Model/Domain/CreateCredentialResponse.php
+++ b/src/Mailgun/Model/Domain/CreateCredentialResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class CreateCredentialResponse implements ApiResponse
+final class CreateCredentialResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Domain/CredentialResponse.php
+++ b/src/Mailgun/Model/Domain/CredentialResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class CredentialResponse implements ApiResponse
+final class CredentialResponse implements ApiResponseInterface
 {
     /**
      * @var int

--- a/src/Mailgun/Model/Domain/DeleteCredentialResponse.php
+++ b/src/Mailgun/Model/Domain/DeleteCredentialResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class DeleteCredentialResponse implements ApiResponse
+final class DeleteCredentialResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Domain/DeleteResponse.php
+++ b/src/Mailgun/Model/Domain/DeleteResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class DeleteResponse implements ApiResponse
+final class DeleteResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Domain/IndexResponse.php
+++ b/src/Mailgun/Model/Domain/IndexResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponse
+final class IndexResponse implements ApiResponseInterface
 {
     /**
      * @var int

--- a/src/Mailgun/Model/Domain/ShowResponse.php
+++ b/src/Mailgun/Model/Domain/ShowResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class ShowResponse implements ApiResponse
+final class ShowResponse implements ApiResponseInterface
 {
     /**
      * @var Domain

--- a/src/Mailgun/Model/Domain/UpdateConnectionResponse.php
+++ b/src/Mailgun/Model/Domain/UpdateConnectionResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class UpdateConnectionResponse implements ApiResponse
+final class UpdateConnectionResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Domain/UpdateCredentialResponse.php
+++ b/src/Mailgun/Model/Domain/UpdateCredentialResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Domain;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class UpdateCredentialResponse implements ApiResponse
+final class UpdateCredentialResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Event/EventResponse.php
+++ b/src/Mailgun/Model/Event/EventResponse.php
@@ -11,12 +11,12 @@ namespace Mailgun\Model\Event;
 
 use Mailgun\Model\PagingProvider;
 use Mailgun\Model\PaginationResponse;
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class EventResponse implements ApiResponse, PagingProvider
+class EventResponse implements ApiResponseInterface, PagingProvider
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Event/EventResponse.php
+++ b/src/Mailgun/Model/Event/EventResponse.php
@@ -9,14 +9,14 @@
 
 namespace Mailgun\Model\Event;
 
-use Mailgun\Model\PagingProvider;
+use Mailgun\Model\PagingProviderInterface;
 use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class EventResponse implements ApiResponseInterface, PagingProvider
+class EventResponse implements ApiResponseInterface, PagingProviderInterface
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Message/SendResponse.php
+++ b/src/Mailgun/Model/Message/SendResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Message;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class SendResponse implements ApiResponse
+class SendResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Message/ShowResponse.php
+++ b/src/Mailgun/Model/Message/ShowResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Message;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ShowResponse implements ApiResponse
+class ShowResponse implements ApiResponseInterface
 {
     /**
      * Only available with message/rfc2822.

--- a/src/Mailgun/Model/PagingProviderInterface.php
+++ b/src/Mailgun/Model/PagingProviderInterface.php
@@ -12,7 +12,7 @@ namespace Mailgun\Model;
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-interface PagingProvider
+interface PagingProviderInterface
 {
     /**
      * Returns the `$paging->next` URL.

--- a/src/Mailgun/Model/Route/Response/CreateResponse.php
+++ b/src/Mailgun/Model/Route/Response/CreateResponse.php
@@ -10,12 +10,12 @@
 namespace Mailgun\Model\Route\Response;
 
 use Mailgun\Model\Route\Route;
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>
  */
-final class CreateResponse implements ApiResponse
+final class CreateResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Route/Response/DeleteResponse.php
+++ b/src/Mailgun/Model/Route/Response/DeleteResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Route\Response;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>
  */
-final class DeleteResponse implements ApiResponse
+final class DeleteResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Route/Response/IndexResponse.php
+++ b/src/Mailgun/Model/Route/Response/IndexResponse.php
@@ -10,12 +10,12 @@
 namespace Mailgun\Model\Route\Response;
 
 use Mailgun\Model\Route\Route;
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>
  */
-final class IndexResponse implements ApiResponse
+final class IndexResponse implements ApiResponseInterface
 {
     /**
      * @var int

--- a/src/Mailgun/Model/Route/Response/ShowResponse.php
+++ b/src/Mailgun/Model/Route/Response/ShowResponse.php
@@ -10,12 +10,12 @@
 namespace Mailgun\Model\Route\Response;
 
 use Mailgun\Model\Route\Route;
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>
  */
-final class ShowResponse implements ApiResponse
+final class ShowResponse implements ApiResponseInterface
 {
     /**
      * @var Route|null

--- a/src/Mailgun/Model/Route/Response/UpdateResponse.php
+++ b/src/Mailgun/Model/Route/Response/UpdateResponse.php
@@ -9,13 +9,13 @@
 
 namespace Mailgun\Model\Route\Response;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\Route\Route;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>
  */
-final class UpdateResponse implements ApiResponse
+final class UpdateResponse implements ApiResponseInterface
 {
     /**
      * @var string|null

--- a/src/Mailgun/Model/Stats/AllResponse.php
+++ b/src/Mailgun/Model/Stats/AllResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Stats;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class AllResponse implements ApiResponse
+final class AllResponse implements ApiResponseInterface
 {
     /**
      * @var int

--- a/src/Mailgun/Model/Stats/TotalResponse.php
+++ b/src/Mailgun/Model/Stats/TotalResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Stats;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class TotalResponse implements ApiResponse
+final class TotalResponse implements ApiResponseInterface
 {
     /**
      * @var \DateTime

--- a/src/Mailgun/Model/Suppression/BaseResponse.php
+++ b/src/Mailgun/Model/Suppression/BaseResponse.php
@@ -9,14 +9,14 @@
 
 namespace Mailgun\Model\Suppression;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * Serves only as an abstract base for Suppression API code.
  *
  * @author Sean Johnson <sean@mailgun.com>
  */
-abstract class BaseResponse implements ApiResponse
+abstract class BaseResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Suppression/Bounce/IndexResponse.php
+++ b/src/Mailgun/Model/Suppression/Bounce/IndexResponse.php
@@ -11,12 +11,12 @@ namespace Mailgun\Model\Suppression\Bounce;
 
 use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\PaginationResponse;
-use Mailgun\Model\PagingProvider;
+use Mailgun\Model\PagingProviderInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponseInterface, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProviderInterface
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Suppression/Bounce/IndexResponse.php
+++ b/src/Mailgun/Model/Suppression/Bounce/IndexResponse.php
@@ -9,14 +9,14 @@
 
 namespace Mailgun\Model\Suppression\Bounce;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\PagingProvider;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponse, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProvider
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Suppression/Bounce/ShowResponse.php
+++ b/src/Mailgun/Model/Suppression/Bounce/ShowResponse.php
@@ -9,11 +9,11 @@
 
 namespace Mailgun\Model\Suppression\Bounce;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class ShowResponse extends Bounce implements ApiResponse
+final class ShowResponse extends Bounce implements ApiResponseInterface
 {
 }

--- a/src/Mailgun/Model/Suppression/Complaint/IndexResponse.php
+++ b/src/Mailgun/Model/Suppression/Complaint/IndexResponse.php
@@ -11,12 +11,12 @@ namespace Mailgun\Model\Suppression\Complaint;
 
 use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\PaginationResponse;
-use Mailgun\Model\PagingProvider;
+use Mailgun\Model\PagingProviderInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponseInterface, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProviderInterface
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Suppression/Complaint/IndexResponse.php
+++ b/src/Mailgun/Model/Suppression/Complaint/IndexResponse.php
@@ -9,14 +9,14 @@
 
 namespace Mailgun\Model\Suppression\Complaint;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\PagingProvider;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponse, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProvider
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Suppression/Complaint/ShowResponse.php
+++ b/src/Mailgun/Model/Suppression/Complaint/ShowResponse.php
@@ -9,11 +9,11 @@
 
 namespace Mailgun\Model\Suppression\Complaint;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class ShowResponse extends Complaint implements ApiResponse
+final class ShowResponse extends Complaint implements ApiResponseInterface
 {
 }

--- a/src/Mailgun/Model/Suppression/Unsubscribe/IndexResponse.php
+++ b/src/Mailgun/Model/Suppression/Unsubscribe/IndexResponse.php
@@ -11,12 +11,12 @@ namespace Mailgun\Model\Suppression\Unsubscribe;
 
 use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\PaginationResponse;
-use Mailgun\Model\PagingProvider;
+use Mailgun\Model\PagingProviderInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponseInterface, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProviderInterface
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Suppression/Unsubscribe/IndexResponse.php
+++ b/src/Mailgun/Model/Suppression/Unsubscribe/IndexResponse.php
@@ -9,14 +9,14 @@
 
 namespace Mailgun\Model\Suppression\Unsubscribe;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\PagingProvider;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class IndexResponse implements ApiResponse, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProvider
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Suppression/Unsubscribe/ShowResponse.php
+++ b/src/Mailgun/Model/Suppression/Unsubscribe/ShowResponse.php
@@ -9,11 +9,11 @@
 
 namespace Mailgun\Model\Suppression\Unsubscribe;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Sean Johnson <sean@mailgun.com>
  */
-final class ShowResponse extends Unsubscribe implements ApiResponse
+final class ShowResponse extends Unsubscribe implements ApiResponseInterface
 {
 }

--- a/src/Mailgun/Model/Tag/DeleteResponse.php
+++ b/src/Mailgun/Model/Tag/DeleteResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Tag;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class DeleteResponse implements ApiResponse
+final class DeleteResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Tag/IndexResponse.php
+++ b/src/Mailgun/Model/Tag/IndexResponse.php
@@ -11,12 +11,12 @@ namespace Mailgun\Model\Tag;
 
 use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\PagingProvider;
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class IndexResponse implements ApiResponse, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProvider
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Tag/IndexResponse.php
+++ b/src/Mailgun/Model/Tag/IndexResponse.php
@@ -10,13 +10,13 @@
 namespace Mailgun\Model\Tag;
 
 use Mailgun\Model\PaginationResponse;
-use Mailgun\Model\PagingProvider;
+use Mailgun\Model\PagingProviderInterface;
 use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class IndexResponse implements ApiResponseInterface, PagingProvider
+final class IndexResponse implements ApiResponseInterface, PagingProviderInterface
 {
     use PaginationResponse;
 

--- a/src/Mailgun/Model/Tag/ShowResponse.php
+++ b/src/Mailgun/Model/Tag/ShowResponse.php
@@ -9,11 +9,11 @@
 
 namespace Mailgun\Model\Tag;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class ShowResponse extends Tag implements ApiResponse
+final class ShowResponse extends Tag implements ApiResponseInterface
 {
 }

--- a/src/Mailgun/Model/Tag/StatisticsResponse.php
+++ b/src/Mailgun/Model/Tag/StatisticsResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Tag;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class StatisticsResponse implements ApiResponse
+final class StatisticsResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Tag/UpdateResponse.php
+++ b/src/Mailgun/Model/Tag/UpdateResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Tag;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class UpdateResponse implements ApiResponse
+final class UpdateResponse implements ApiResponseInterface
 {
     /**
      * @var string

--- a/src/Mailgun/Model/Webhook/BaseResponse.php
+++ b/src/Mailgun/Model/Webhook/BaseResponse.php
@@ -9,14 +9,14 @@
 
 namespace Mailgun\Model\Webhook;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * This is only mean to be the base response for Webhook API.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class BaseResponse implements ApiResponse
+abstract class BaseResponse implements ApiResponseInterface
 {
     /**
      * @var array

--- a/src/Mailgun/Model/Webhook/IndexResponse.php
+++ b/src/Mailgun/Model/Webhook/IndexResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Webhook;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class IndexResponse implements ApiResponse
+class IndexResponse implements ApiResponseInterface
 {
     /**
      * @var array

--- a/src/Mailgun/Model/Webhook/ShowResponse.php
+++ b/src/Mailgun/Model/Webhook/ShowResponse.php
@@ -9,12 +9,12 @@
 
 namespace Mailgun\Model\Webhook;
 
-use Mailgun\Model\ApiResponse;
+use Mailgun\Model\ApiResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ShowResponse implements ApiResponse
+class ShowResponse implements ApiResponseInterface
 {
     /**
      * @var array

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -65,7 +65,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         }
 
         if (null === $hydrator) {
-            $hydrator = $this->getMockBuilder('Mailgun\Hydrator\Hydrator')
+            $hydrator = $this->getMockBuilder('Mailgun\Hydrator\HydratorInterface')
                 ->setMethods(['hydrate'])
                 ->getMock();
         }


### PR DESCRIPTION
As per my own inspection running SensioLabs Insight:
An `Interface` file should end with `Interface` for better clarity.

This PR should fix https://github.com/mailgun/mailgun-php/issues/417