### PR TITLE
Make sure we do not instantiate an abstract class.

### DIFF
--- a/src/Mailgun/Model/Domain/AbstractDomainResponse.php
+++ b/src/Mailgun/Model/Domain/AbstractDomainResponse.php
@@ -68,7 +68,7 @@ abstract class AbstractDomainResponse implements ApiResponse
             }
         }
 
-        return new self($domain, $rx, $tx, $message);
+        return new static($domain, $rx, $tx, $message);
     }
 
     /**


### PR DESCRIPTION
Fixed minor bug introduced in #420. 

FYI @Eugst, We missed this in the review. 