### PR TITLE
fix: Validate file name length

### DIFF
--- a/src/Mailgun/Api/Message.php
+++ b/src/Mailgun/Api/Message.php
@@ -82,7 +82,7 @@ class Message extends HttpApi
         $params['to'] = $recipients;
         $postDataMultipart = $this->prepareMultipartParameters($params);
 
-        if (is_file($message)) {
+         if (strlen($message) < PHP_MAXPATHLEN && is_file($message)) {
             $fileData = ['filePath' => $message];
         } else {
             $fileData = [

--- a/src/Mailgun/Api/Message.php
+++ b/src/Mailgun/Api/Message.php
@@ -82,7 +82,7 @@ class Message extends HttpApi
         $params['to'] = $recipients;
         $postDataMultipart = $this->prepareMultipartParameters($params);
 
-         if (strlen($message) < PHP_MAXPATHLEN && is_file($message)) {
+        if (strlen($message) < PHP_MAXPATHLEN && is_file($message)) {
             $fileData = ['filePath' => $message];
         } else {
             $fileData = [

--- a/tests/Api/MessageTest.php
+++ b/tests/Api/MessageTest.php
@@ -118,7 +118,7 @@ class MessageTest extends TestCase
             ->method('httpPostRaw')
             ->willReturn(new Response());
 
-        $message = str_repeat('a', PHP_MAXPATHLEN). ' and some more';
+        $message = str_repeat('a', PHP_MAXPATHLEN) . ' and some more';
         $api->sendMime('foo', ['mailbox@myapp.com'], $message, []);
     }
 

--- a/tests/Api/MessageTest.php
+++ b/tests/Api/MessageTest.php
@@ -118,7 +118,7 @@ class MessageTest extends TestCase
             ->method('httpPostRaw')
             ->willReturn(new Response());
 
-        $message = str_repeat('a', PHP_MAXPATHLEN) . ' and some more';
+        $message = str_repeat('a', PHP_MAXPATHLEN).' and some more';
         $api->sendMime('foo', ['mailbox@myapp.com'], $message, []);
     }
 

--- a/tests/Api/MessageTest.php
+++ b/tests/Api/MessageTest.php
@@ -111,6 +111,17 @@ class MessageTest extends TestCase
         $api->show('url', true);
     }
 
+    public function testSendMimeWithLongMessage()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('httpPostRaw')
+            ->willReturn(new Response());
+
+        $message = str_repeat('a', PHP_MAXPATHLEN). ' and some more';
+        $api->sendMime('foo', ['mailbox@myapp.com'], $message, []);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
$message could contain a large email text that if sent to is_file it could break with this error:
` is_file(): File name is longer than the maximum allowed path `
This validation prevents using is_file if the $message is longer than the allowed path.