### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,5 @@ information about our API.
 If you find a bug, please submit the issue in Github directly. 
 [Mailgun-PHP Issues](https://github.com/mailgun/mailgun-php/issues)
 
-As always, if you need additional assistance, drop us a note through your Control Panel at
-[https://mailgun.com/cp/support](https://mailgun.com/cp/support).
-
+As always, if you need additional assistance, drop us a note through your account at
+https://app.mailgun.com/app/support/list.

--- a/README.md
+++ b/README.md
@@ -194,4 +194,4 @@ If you find a bug, please submit the issue in Github directly.
 [Mailgun-PHP Issues](https://github.com/mailgun/mailgun-php/issues)
 
 As always, if you need additional assistance, drop us a note through your account at
-https://app.mailgun.com/app/support/list.
+[https://app.mailgun.com/app/support/list](https://app.mailgun.com/app/support/list).


### PR DESCRIPTION
The old link pointed to a support link at Mailgun's control panel, which leads to a [404 page](https://www.mailgun.com/cp/support). I've updated to the working [support link](https://app.mailgun.com/app/support/list).