### PR TITLE
Fix type error when creating tags 

### DIFF
--- a/src/Mailgun/Model/Tag/Tag.php
+++ b/src/Mailgun/Model/Tag/Tag.php
@@ -52,7 +52,7 @@ class Tag
      */
     public static function create(array $data)
     {
-        return new self($data['tag'], $data['description'], $data['first-seen'], $data['last-seen']);
+        return new self($data['tag'], $data['description'], new \DateTime($data['first-seen']), new \DateTime($data['last-seen']));
     }
 
     /**

--- a/src/Mailgun/Model/Tag/Tag.php
+++ b/src/Mailgun/Model/Tag/Tag.php
@@ -70,4 +70,20 @@ class Tag
     {
         return $this->description;
     }
+
+    /**
+     * @return \DateTime
+     */
+    public function getFirstSeen()
+    {
+        return $this->firstSeen;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getLastSeen()
+    {
+        return $this->lastSeen;
+    }
 }

--- a/tests/Model/Tag/TagTest.php
+++ b/tests/Model/Tag/TagTest.php
@@ -22,7 +22,7 @@ class TagTest extends BaseModelTest
             'tag' => $expectedTag,
             'description' => $expectedDescription,
             'first-seen' => '2018-12-13T05:00:00Z',
-            'last-seen' => '2018-12-13T12:00:00Z'
+            'last-seen' => '2018-12-13T12:00:00Z',
         ]);
 
         $this->assertInstanceOf(TagModel::class, $tag);

--- a/tests/Model/Tag/TagTest.php
+++ b/tests/Model/Tag/TagTest.php
@@ -18,15 +18,19 @@ class TagTest extends BaseModelTest
     {
         $expectedTag = 'foo';
         $expectedDescription = 'bar';
+        $expectedFirstSeen = '2018-12-13T05:00:00Z';
+        $expectedLastSeeen = '2018-12-13T12:00:00Z';
         $tag = TagModel::create([
             'tag' => $expectedTag,
             'description' => $expectedDescription,
-            'first-seen' => '2018-12-13T05:00:00Z',
-            'last-seen' => '2018-12-13T12:00:00Z',
+            'first-seen' => $expectedFirstSeen,
+            'last-seen' => $expectedLastSeeen,
         ]);
 
         $this->assertInstanceOf(TagModel::class, $tag);
         $this->assertSame($expectedTag, $tag->getTag());
         $this->assertSame($expectedDescription, $tag->getDescription());
+        $this->assertEquals($expectedFirstSeen, $tag->getFirstSeen()->format('Y-m-d\TH:i:s\Z'));
+        $this->assertEquals($expectedLastSeeen, $tag->getLastSeen()->format('Y-m-d\TH:i:s\Z'));
     }
 }

--- a/tests/Model/Tag/TagTest.php
+++ b/tests/Model/Tag/TagTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+namespace Mailgun\Tests\Model\Tag;
+
+use Mailgun\Model\Tag\Tag as TagModel;
+use Mailgun\Tests\Model\BaseModelTest;
+
+class TagTest extends BaseModelTest
+{
+    public function testCreate()
+    {
+        $expectedTag = 'foo';
+        $expectedDescription = 'bar';
+        $tag = TagModel::create([
+            'tag' => $expectedTag,
+            'description' => $expectedDescription,
+            'first-seen' => '2018-12-13T05:00:00Z',
+            'last-seen' => '2018-12-13T12:00:00Z'
+        ]);
+
+        $this->assertInstanceOf(TagModel::class, $tag);
+        $this->assertSame($expectedTag, $tag->getTag());
+        $this->assertSame($expectedDescription, $tag->getDescription());
+    }
+}


### PR DESCRIPTION
I just ran into this bug when attempting to call `$mailgun->tags()->index('my.domain.com')`. Fixes #480.