### PR TITLE
Missing method for the MailingList API endpoints?

### DIFF
--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -121,6 +121,11 @@ final class Mailgun
         return new Api\Message($this->httpClient, $this->requestBuilder, $this->hydrator);
     }
 
+    public function mailingList(): API\MailingList
+    {
+        return new Api\MailingList($this->httpClient, $this->requestBuilder, $this->hydrator);
+    }
+
     public function ips(): Api\Ip
     {
         return new Api\Ip($this->httpClient, $this->requestBuilder, $this->hydrator);

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Mailgun;
 
 use Http\Client\HttpClient;
+use Mailgun\Api\MailingList;
 use Mailgun\HttpClient\HttpClientConfigurator;
 use Mailgun\HttpClient\Plugin\History;
 use Mailgun\HttpClient\RequestBuilder;
@@ -121,9 +122,9 @@ final class Mailgun
         return new Api\Message($this->httpClient, $this->requestBuilder, $this->hydrator);
     }
 
-    public function mailingList(): API\MailingList
+    public function mailingList(): MailingList
     {
-        return new Api\MailingList($this->httpClient, $this->requestBuilder, $this->hydrator);
+        return new MailingList($this->httpClient, $this->requestBuilder, $this->hydrator);
     }
 
     public function ips(): Api\Ip


### PR DESCRIPTION
Hey @Nyholm 

I think that the PR to build the Mailing List integration (https://github.com/mailgun/mailgun-php/pull/514) didn't include the call to get access to all API Endpoints; adding it now.

Cheers,