### PR TITLE
Mailgun-461: Validate limits

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -40,6 +40,8 @@ class Domain extends HttpApi
      */
     public function index(int $limit = 100, int $skip = 0)
     {
+        Assert::range($limit, 1, 1000);
+
         $params = [
             'limit' => $limit,
             'skip' => $skip,

--- a/src/Api/Event.php
+++ b/src/Api/Event.php
@@ -30,6 +30,10 @@ class Event extends HttpApi
     {
         Assert::stringNotEmpty($domain);
 
+        if (array_key_exists('limit', $params)) {
+            Assert::range($params['limit'], 1, 300);
+        }
+
         $response = $this->httpGet(sprintf('/v3/%s/events', $domain), $params);
 
         return $this->hydrateResponse($response, EventResponse::class);

--- a/src/Api/MailingList.php
+++ b/src/Api/MailingList.php
@@ -40,8 +40,7 @@ class MailingList extends HttpApi
      */
     public function pages(int $limit = 100)
     {
-        Assert::integer($limit);
-        Assert::greaterThan($limit, 0);
+        Assert::range($limit, 1, 1000);
 
         $params = [
             'limit' => $limit,

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -37,6 +37,7 @@ class Route extends HttpApi
     {
         Assert::greaterThan($limit, 0);
         Assert::greaterThanEq($skip, 0);
+        Assert::range($limit, 1, 1000);
 
         $params = [
             'limit' => $limit,

--- a/src/Api/Tag.php
+++ b/src/Api/Tag.php
@@ -38,6 +38,8 @@ class Tag extends HttpApi
     public function index(string $domain, int $limit = 100)
     {
         Assert::stringNotEmpty($domain);
+        Assert::lessThanEq($limit, 1000);
+
         $params = [
             'limit' => $limit,
         ];

--- a/src/Api/Tag.php
+++ b/src/Api/Tag.php
@@ -38,7 +38,7 @@ class Tag extends HttpApi
     public function index(string $domain, int $limit = 100)
     {
         Assert::stringNotEmpty($domain);
-        Assert::lessThanEq($limit, 1000);
+        Assert::range($limit, 1, 1000);
 
         $params = [
             'limit' => $limit,


### PR DESCRIPTION
This should fix https://github.com/mailgun/mailgun-php/issues/461

I've added the assets to validate the limits for pagination according to the responses that I got from Mailgun support team.

The check validates a range, to match with the existing checks that we have for suppressions, that were added during the development phase of those features.