### PR TITLE
Fix attachment renaming

### DIFF
--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -270,7 +270,7 @@ class MessageBuilder
 
         $this->message['attachment'][] = [
             'filePath' => $attachmentPath,
-            'remoteName' => $attachmentName,
+            'filename' => $attachmentName,
         ];
 
         return $this;


### PR DESCRIPTION
The key should be 'filename' instead of 'RemoteName'