### PR TITLE
Fix attachment and inline image renaming

### DIFF
--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -270,7 +270,7 @@ class MessageBuilder
 
         $this->message['attachment'][] = [
             'filePath' => $attachmentPath,
-            'remoteName' => $attachmentName,
+            'filename' => $attachmentName,
         ];
 
         return $this;
@@ -284,7 +284,7 @@ class MessageBuilder
 
         $this->message['inline'][] = [
             'filePath' => $inlineImagePath,
-            'remoteName' => $inlineImageName,
+            'filename' => $inlineImageName,
         ];
 
         return $this;

--- a/tests/Message/MessageBuilderTest.php
+++ b/tests/Message/MessageBuilderTest.php
@@ -150,11 +150,11 @@ class MessageBuilderTest extends MailgunTestCase
             [
                 [
                     'filePath' => '@../TestAssets/mailgun_icon.png',
-                    'remoteName' => null,
+                    'filename' => null,
                 ],
                 [
                     'filePath' => '@../TestAssets/rackspace_logo.png',
-                    'remoteName' => null,
+                    'filename' => null,
                 ],
             ],
             $message['attachment']
@@ -170,11 +170,11 @@ class MessageBuilderTest extends MailgunTestCase
             [
                 [
                     'filePath' => '@../TestAssets/mailgun_icon.png',
-                    'remoteName' => null,
+                    'filename' => null,
                 ],
                 [
                     'filePath' => '@../TestAssets/rackspace_logo.png',
-                    'remoteName' => null,
+                    'filename' => null,
                 ],
             ],
             $message['inline']
@@ -190,11 +190,11 @@ class MessageBuilderTest extends MailgunTestCase
             [
                 [
                     'filePath' => '@../TestAssets/mailgun_icon.png',
-                    'remoteName' => 'mg_icon.png',
+                    'filename' => 'mg_icon.png',
                 ],
                 [
                     'filePath' => '@../TestAssets/rackspace_logo.png',
-                    'remoteName' => 'rs_logo.png',
+                    'filename' => 'rs_logo.png',
                 ],
             ],
             $message['attachment']
@@ -210,11 +210,11 @@ class MessageBuilderTest extends MailgunTestCase
             [
                 [
                     'filePath' => '@../TestAssets/mailgun_icon.png',
-                    'remoteName' => 'mg_icon.png',
+                    'filename' => 'mg_icon.png',
                 ],
                 [
                     'filePath' => '@../TestAssets/rackspace_logo.png',
-                    'remoteName' => 'rs_logo.png',
+                    'filename' => 'rs_logo.png',
                 ],
             ],
             $message['inline']


### PR DESCRIPTION
As detailed in previous PR, the attachment and inline image new names are expected to be associated to the 'filename' key by Message.php