### PR TITLE
Fixes #573

### DIFF
--- a/src/HttpClient/Plugin/HistoryTrait.php
+++ b/src/HttpClient/Plugin/HistoryTrait.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\RequestInterface;
 /*
  * Below is a some code to make the History plugin compatible with both 1.x and 2.x of php-client/client-common
  */
-if (\class_exists(\Http\Client\Common\HttpMethodsClientInterface::class)) {
+if (\interface_exists(\Http\Client\Common\HttpMethodsClientInterface::class)) {
     /**
      * @internal code for php-http/client-common:2.x
      */


### PR DESCRIPTION
because `\Http\Client\Common\HttpMethodsClientInterface` is an interface, not a class and `class_exists` returns `false` even if interface is actually exists since PHP version 5.0.2