### PR TITLE
Docker's PHP 7.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.1'
+
+services:
+
+    php:
+        container_name: mailgun-php-sdk-php
+        build:
+            context: ./docker/php
+        ports:
+            - 9000:9000
+        working_dir: /maingun-php-sdk
+        volumes:
+            - .:/maingun-php-sdk:cached

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:7.1-fpm
+
+MAINTAINER David Garcia <me@davidgarcia.cat>
+
+# Install dependencies for PHP
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RUN apt-get update
+RUN apt-get install -y openssl git unzip iputils-ping telnet
+
+# Download and install Composer
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN composer --version
+
+# Enable PHP ZIP Extension
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+
+RUN apt-get install -y zip unzip zlib1g-dev libzip-dev
+RUN docker-php-ext-install zip
+
+# Enable PHP XDebug Extension
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RUN pecl install xdebug
+
+RUN docker-php-ext-enable xdebug
+
+RUN echo "error_reporting = E_ALL" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "display_startup_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "display_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "xdebug.remote_connect_back=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "xdebug.idekey=\"PHPSTORM\"" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "xdebug.remote_port=9001" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini


### PR DESCRIPTION
Adding Docker's PHP 7.1, so that we can use it during the development phase instead of installing a given PHP version directly into the OS:

```
docker-compose up --build --no-start
docker-compose start

docker exec -it mailgun-php-sdk-php composer install

docker exec -it mailgun-php-sdk-php vendor/bin/phpunit
```