### PR TITLE
Cast route `priority` param to string (fix #652)

### DIFF
--- a/src/Mailgun/Api/Route.php
+++ b/src/Mailgun/Api/Route.php
@@ -82,7 +82,7 @@ class Route extends HttpApi
         Assert::integer($priority);
 
         $params = [
-            'priority' => $priority,
+            'priority' => (string) $priority,
             'expression' => $expression,
             'action' => $actions,
             'description' => $description,

--- a/tests/Api/RouteTest.php
+++ b/tests/Api/RouteTest.php
@@ -47,7 +47,7 @@ class RouteTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('httpPost')
-            ->with([
+            ->with('/v3/routes', [
                 'priority' => '100',
                 'expression' => 'catch_all()',
                 'action' => ['forward("mailbox@myapp.com")'],

--- a/tests/Api/RouteTest.php
+++ b/tests/Api/RouteTest.php
@@ -47,6 +47,12 @@ class RouteTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('httpPost')
+            ->with([
+                'priority' => '100',
+                'expression' => 'catch_all()',
+                'action' => ['forward("mailbox@myapp.com")'],
+                'description' => 'example'
+            ])
             ->willReturn(new Response());
 
         $api->create('catch_all()', ['forward("mailbox@myapp.com")'], 'example', 100);


### PR DESCRIPTION
This PR fixes the issue #652 by casting the `priority` parameter to string before calling `httpPost` method.

This fix is for `v2.x`, I'm not sure if v3.0.0 have same issue.

I really suggest this fix to be merged immediately and released a patch version containing it, since the last v2.8.1 is broken.