### PR TITLE
Bug fix with getContentIdMap return type

### DIFF
--- a/src/Model/Message/ShowResponse.php
+++ b/src/Model/Message/ShowResponse.php
@@ -131,7 +131,7 @@ final class ShowResponse implements ApiResponse
         return $this->messageUrl;
     }
 
-    public function getContentIdMap(): ?string
+    public function getContentIdMap(): ?array
     {
         return $this->contentIdMap;
     }


### PR DESCRIPTION
The response from the api is an array and not a string.