### PR TITLE
fix /v3/domains/{domain}/ips endpoint

### DIFF
--- a/src/Api/Ip.php
+++ b/src/Api/Ip.php
@@ -53,7 +53,7 @@ class Ip extends HttpApi
     {
         Assert::stringNotEmpty($domain);
 
-        $response = $this->httpGet(sprintf('/v3/domains/%s/ip', $domain));
+        $response = $this->httpGet(sprintf('/v3/domains/%s/ips', $domain));
 
         return $this->hydrateResponse($response, IndexResponse::class);
     }


### PR DESCRIPTION
`/v3/domains/{domain}/ips` is the correct endpoint per https://documentation.mailgun.com/en/latest/api-ips.html#ips