### PR TITLE
Expose reject responses

### DIFF
--- a/src/Model/Event/Event.php
+++ b/src/Model/Event/Event.php
@@ -29,6 +29,7 @@ final class Event
     private $ip;
     private $clientInfo;
     private $reason;
+    private $reject;
     private $userVariables;
     private $flags;
     private $routes;
@@ -61,6 +62,7 @@ final class Event
         $model->deliveryStatus = $data['delivery-status'] ?? [];
         $model->severity = $data['severity'] ?? '';
         $model->reason = $data['reason'] ?? '';
+        $model->reject = $data['reject'] ?? [];
         $model->geolocation = $data['geolocation'] ?? [];
         $model->ip = $data['ip'] ?? '';
         $model->clientInfo = $data['client-info'] ?? [];
@@ -142,6 +144,11 @@ final class Event
     public function getReason(): string
     {
         return $this->reason;
+    }
+
+    public function getReject(): array
+    {
+        return $this->reject;
     }
 
     public function getUserVariables(): array


### PR DESCRIPTION
Currently it's not possible to see `reject` responses from the API. Example of real response would be:

```
"reject": {
	"reason": "The domain is unverified and requires DNS configuration. Log in to your control panel to view required DNS records.",
	"description": ""
},
```