### PR TITLE
feat: add array support to webhook handling

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -321,12 +321,12 @@ $mailgun->webhooks()->show('example.com', 'accept');
 
 #### Create a webhooks
 ```php
-$mailgun->webhooks()->create('example.com', 'accept', 'https://www.exmple.com/webhook');
+$mailgun->webhooks()->create('example.com', 'opened', [ 'https://www.exmple.com/webhook' ]);
 ```
 
 #### Update a webhooks
 ```php
-$mailgun->webhooks()->update('example.com', 4711, 'https://www.exmple.com/webhook');
+$mailgun->webhooks()->update('example.com', 4711, [ 'https://www.exmple.com/webhook' ]);
 ```
 
 #### Delete a webhooks

--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -35,7 +35,6 @@ class Domain extends HttpApi
     /**
      * Returns a list of domains on the account.
      *
-     *
      * @return IndexResponse
      */
     public function index(int $limit = 100, int $skip = 0)

--- a/src/Api/HttpApi.php
+++ b/src/Api/HttpApi.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Mailgun\Api;
 
-use Mailgun\Exception\UnknownErrorException;
-use Mailgun\Hydrator\Hydrator;
-use Mailgun\Hydrator\NoopHydrator;
 use Mailgun\Exception\HttpClientException;
 use Mailgun\Exception\HttpServerException;
+use Mailgun\Exception\UnknownErrorException;
 use Mailgun\HttpClient\RequestBuilder;
+use Mailgun\Hydrator\Hydrator;
+use Mailgun\Hydrator\NoopHydrator;
 use Psr\Http\Client as Psr18;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Api/Ip.php
+++ b/src/Api/Ip.php
@@ -27,7 +27,6 @@ class Ip extends HttpApi
     /**
      * Returns a list of IPs.
      *
-     *
      * @return IndexResponse|ResponseInterface
      */
     public function index(bool $dedicated = false)
@@ -46,7 +45,6 @@ class Ip extends HttpApi
     /**
      * Returns a list of IPs assigned to a domain.
      *
-     *
      * @return IndexResponse|ResponseInterface
      */
     public function domainIndex(string $domain)
@@ -61,7 +59,6 @@ class Ip extends HttpApi
     /**
      * Returns a single ip.
      *
-     *
      * @return ShowResponse|ResponseInterface
      */
     public function show(string $ip)
@@ -75,7 +72,6 @@ class Ip extends HttpApi
 
     /**
      * Assign a dedicated IP to the domain specified.
-     *
      *
      * @return UpdateResponse|ResponseInterface
      */
@@ -95,8 +91,6 @@ class Ip extends HttpApi
 
     /**
      * Unassign an IP from the domain specified.
-     *
-
      *
      * @return UpdateResponse|ResponseInterface
      */

--- a/src/Api/MailingList/Member.php
+++ b/src/Api/MailingList/Member.php
@@ -128,11 +128,7 @@ class Member extends HttpApi
 
         // workaround for webmozart/asserts <= 1.2
         if (count($members) > 1000) {
-            throw new InvalidArgumentException(sprintf(
-                'Expected an Array to contain at most %2$d elements. Got: %d',
-                1000,
-                count($members)
-            ));
+            throw new InvalidArgumentException(sprintf('Expected an Array to contain at most %2$d elements. Got: %d', 1000, count($members)));
         }
 
         foreach ($members as $data) {

--- a/src/Api/Message.php
+++ b/src/Api/Message.php
@@ -71,7 +71,7 @@ class Message extends HttpApi
      *
      * @return SendResponse|ResponseInterface
      */
-    public function sendMime(string $domain, array $recipients, string  $message, array $params)
+    public function sendMime(string $domain, array $recipients, string $message, array $params)
     {
         Assert::string($domain);
         Assert::notEmpty($domain);

--- a/src/Api/Suppression.php
+++ b/src/Api/Suppression.php
@@ -14,9 +14,9 @@ namespace Mailgun\Api;
 use Mailgun\Api\Suppression\Bounce;
 use Mailgun\Api\Suppression\Complaint;
 use Mailgun\Api\Suppression\Unsubscribe;
+use Mailgun\HttpClient\RequestBuilder;
 use Mailgun\Hydrator\Hydrator;
 use Psr\Http\Client\ClientInterface;
-use Mailgun\HttpClient\RequestBuilder;
 
 /**
  * @see https://documentation.mailgun.com/api-suppressions.html

--- a/src/Api/Tag.php
+++ b/src/Api/Tag.php
@@ -67,7 +67,6 @@ class Tag extends HttpApi
     /**
      * Update a tag.
      *
-     *
      * @return UpdateResponse|ResponseInterface
      */
     public function update(string $domain, string $tag, string $description)
@@ -87,7 +86,6 @@ class Tag extends HttpApi
     /**
      * Returns statistics for a single tag.
      *
-     *
      * @return StatisticsResponse|ResponseInterface
      */
     public function stats(string $domain, string $tag, array $params)
@@ -102,7 +100,6 @@ class Tag extends HttpApi
 
     /**
      * Removes a tag from the account.
-     *
      *
      * @return DeleteResponse|ResponseInterface
      */

--- a/src/Api/Webhook.php
+++ b/src/Api/Webhook.php
@@ -12,15 +12,15 @@ declare(strict_types=1);
 namespace Mailgun\Api;
 
 use Mailgun\Assert;
+use Mailgun\HttpClient\RequestBuilder;
 use Mailgun\Hydrator\Hydrator;
 use Mailgun\Model\Webhook\CreateResponse;
 use Mailgun\Model\Webhook\DeleteResponse;
 use Mailgun\Model\Webhook\IndexResponse;
 use Mailgun\Model\Webhook\ShowResponse;
 use Mailgun\Model\Webhook\UpdateResponse;
-use Mailgun\HttpClient\RequestBuilder;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @see https://documentation.mailgun.com/en/latest/api-webhooks.html

--- a/src/Api/Webhook.php
+++ b/src/Api/Webhook.php
@@ -88,7 +88,7 @@ class Webhook extends HttpApi
     /**
      * @return CreateResponse|ResponseInterface
      */
-    public function create(string $domain, string $id, string $url)
+    public function create(string $domain, string $id, array $url)
     {
         Assert::notEmpty($domain);
         Assert::notEmpty($id);
@@ -107,7 +107,7 @@ class Webhook extends HttpApi
     /**
      * @return UpdateResponse|ResponseInterface
      */
-    public function update(string $domain, string $id, string $url)
+    public function update(string $domain, string $id, array $url)
     {
         Assert::notEmpty($domain);
         Assert::notEmpty($id);

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -15,10 +15,10 @@ use Http\Client\Common\PluginClient;
 use Mailgun\HttpClient\HttpClientConfigurator;
 use Mailgun\HttpClient\Plugin\History;
 use Mailgun\HttpClient\RequestBuilder;
-use Mailgun\Hydrator\ModelHydrator;
 use Mailgun\Hydrator\Hydrator;
-use Psr\Http\Message\ResponseInterface;
+use Mailgun\Hydrator\ModelHydrator;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * This class is the base class for the Mailgun SDK.

--- a/src/Model/Event/EventResponse.php
+++ b/src/Model/Event/EventResponse.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Mailgun\Model\Event;
 
-use Mailgun\Model\PagingProvider;
-use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\ApiResponse;
+use Mailgun\Model\PaginationResponse;
+use Mailgun\Model\PagingProvider;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/src/Model/MailingList/Member/IndexResponse.php
+++ b/src/Model/MailingList/Member/IndexResponse.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Mailgun\Model\MailingList\Member;
 
-use Mailgun\Model\PagingProvider;
-use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\ApiResponse;
+use Mailgun\Model\PaginationResponse;
+use Mailgun\Model\PagingProvider;
 
 final class IndexResponse implements ApiResponse, PagingProvider
 {

--- a/src/Model/MailingList/PagesResponse.php
+++ b/src/Model/MailingList/PagesResponse.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Mailgun\Model\MailingList;
 
-use Mailgun\Model\PagingProvider;
-use Mailgun\Model\PaginationResponse;
 use Mailgun\Model\ApiResponse;
+use Mailgun\Model\PaginationResponse;
+use Mailgun\Model\PagingProvider;
 
 final class PagesResponse implements ApiResponse, PagingProvider
 {

--- a/tests/Api/TagTest.php
+++ b/tests/Api/TagTest.php
@@ -13,7 +13,6 @@ namespace Mailgun\Tests\Api;
 
 use GuzzleHttp\Psr7\Response;
 use Mailgun\Api\Tag;
-use Mailgun\Mailgun;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/tests/Api/WebhookTest.php
+++ b/tests/Api/WebhookTest.php
@@ -79,12 +79,22 @@ class WebhookTest extends TestCase
         $this->setRequestUri('/v3/domains/example.com/webhooks');
         $this->setHydrateClass(CreateResponse::class);
         $this->setRequestBody([
-            'id' => '4711',
-            'url' => 'url',
+            [
+                'name' => 'id',
+                'content' => 'opened'
+            ],
+            [
+                'name' => 'url',
+                'content' => 'url_1'
+            ],
+            [
+                'name' => 'url',
+                'content' => 'url_2'
+            ]
         ]);
 
         $api = $this->getApiInstance('key');
-        $api->create('example.com', '4711', 'url');
+        $api->create('example.com', 'opened', ['url_1', 'url_2']);
     }
 
     public function testUpdate()
@@ -93,11 +103,18 @@ class WebhookTest extends TestCase
         $this->setRequestUri('/v3/domains/example.com/webhooks/4711');
         $this->setHydrateClass(UpdateResponse::class);
         $this->setRequestBody([
-            'url' => 'url',
+            [
+                'name' => 'url',
+                'content' => 'url_1'
+            ],
+            [
+                'name' => 'url',
+                'content' => 'url_2'
+            ]
         ]);
 
         $api = $this->getApiInstance('key');
-        $api->update('example.com', '4711', 'url');
+        $api->update('example.com', '4711', ['url_1', 'url_2'] );
     }
 
     public function testDelete()

--- a/tests/Api/WebhookTest.php
+++ b/tests/Api/WebhookTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace Mailgun\Tests\Api;
 
 use Mailgun\Api\Webhook;
-use Mailgun\Model\Webhook\IndexResponse;
-use Mailgun\Model\Webhook\ShowResponse;
 use Mailgun\Model\Webhook\CreateResponse;
 use Mailgun\Model\Webhook\DeleteResponse;
+use Mailgun\Model\Webhook\IndexResponse;
+use Mailgun\Model\Webhook\ShowResponse;
 use Mailgun\Model\Webhook\UpdateResponse;
 
 class WebhookTest extends TestCase
@@ -81,16 +81,16 @@ class WebhookTest extends TestCase
         $this->setRequestBody([
             [
                 'name' => 'id',
-                'content' => 'opened'
+                'content' => 'opened',
             ],
             [
                 'name' => 'url',
-                'content' => 'url_1'
+                'content' => 'url_1',
             ],
             [
                 'name' => 'url',
-                'content' => 'url_2'
-            ]
+                'content' => 'url_2',
+            ],
         ]);
 
         $api = $this->getApiInstance('key');
@@ -105,16 +105,16 @@ class WebhookTest extends TestCase
         $this->setRequestBody([
             [
                 'name' => 'url',
-                'content' => 'url_1'
+                'content' => 'url_1',
             ],
             [
                 'name' => 'url',
-                'content' => 'url_2'
-            ]
+                'content' => 'url_2',
+            ],
         ]);
 
         $api = $this->getApiInstance('key');
-        $api->update('example.com', '4711', ['url_1', 'url_2'] );
+        $api->update('example.com', '4711', ['url_1', 'url_2']);
     }
 
     public function testDelete()


### PR DESCRIPTION
Change webhook create() $url parameter from string to array to support
multiple URLs
Change webhook update() $url parameter from string to array yo support
multiple URLs