### PR TITLE
Allow php-http/guzzle6-adapter ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",
-        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "nyholm/psr7": "^1.0",
         "nyholm/nsa": "^1.1"
     },


### PR DESCRIPTION
It still uses the same API, just updated for PHP 7