### PR TITLE
Added Support for Mailing List "reply_preference" parameter

### DIFF
--- a/src/Api/MailingList.php
+++ b/src/Api/MailingList.php
@@ -63,18 +63,20 @@ class MailingList extends HttpApi
      *
      * @throws \Exception
      */
-    public function create(string $address, string $name = null, string $description = null, string $accessLevel = 'readonly')
+    public function create(string $address, string $name = null, string $description = null, string $accessLevel = 'readonly', string $replyPreference = 'list')
     {
         Assert::stringNotEmpty($address);
         Assert::nullOrStringNotEmpty($name);
         Assert::nullOrStringNotEmpty($description);
         Assert::oneOf($accessLevel, ['readonly', 'members', 'everyone']);
+        Assert::oneOf($replyPreference, ['list', 'sender']);
 
         $params = [
             'address' => $address,
             'name' => $name,
             'description' => $description,
             'access_level' => $accessLevel,
+            'reply_preference' => $replyPreference
         ];
 
         $response = $this->httpPost('/v3/lists', $params);

--- a/src/Model/MailingList/MailingList.php
+++ b/src/Model/MailingList/MailingList.php
@@ -18,6 +18,7 @@ final class MailingList implements ApiResponse
     private $name;
     private $address;
     private $accessLevel;
+    private $replyPreference;
     private $description;
     private $membersCount;
     private $createdAt;
@@ -28,6 +29,7 @@ final class MailingList implements ApiResponse
         $model->name = $data['name'] ?? null;
         $model->address = $data['address'] ?? null;
         $model->accessLevel = $data['access_level'] ?? null;
+        $model->replyPreference = $data['reply_preference'] ?? null;
         $model->description = $data['description'] ?? null;
         $model->membersCount = (int) ($data['members_count'] ?? 0);
         $model->createdAt = isset($data['created_at']) ? new \DateTimeImmutable($data['created_at']) : null;
@@ -52,6 +54,11 @@ final class MailingList implements ApiResponse
     public function getAccessLevel(): ?string
     {
         return $this->accessLevel;
+    }
+
+    public function getReplyPreference(): ?string
+    {
+        return $this->replyPreference;
     }
 
     public function getDescription(): ?string

--- a/tests/Api/MailingListTest.php
+++ b/tests/Api/MailingListTest.php
@@ -48,6 +48,7 @@ class MailingListTest extends TestCase
             'name' => 'Foo',
             'description' => 'Description',
             'access_level' => 'readonly',
+            'reply_preference' => 'list'
         ];
 
         $api = $this->getApiMock();


### PR DESCRIPTION
## Problem
When creating new Mailing Lists via the SDK, it's not possible to explicitly set the 'reply_preference' parameter. As a result, lists created via the SDK will always default to reply_preference = list.

## Changes
I've updated the following classes to add support for this parameter when creating new mailing lists:
- Mailgun\Model\MailingList\MailingList
- Mailgun\Api\MailingList
- Mailgun\Tests\Api\MailingListTest

## Remaining Issues
This PR doesn't extend to the update method, although I suppose it would be near trivial to make the necessary changes to the API class and its test class.