### PR TITLE
Force dkim authority

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -79,10 +79,11 @@ class Domain extends HttpApi
      * @param string $smtpPass   password for SMTP authentication
      * @param string $spamAction `disable` or `tag` - inbound spam filtering
      * @param bool   $wildcard   domain will accept email for subdomains
+     * @param bool   $forceDkimAuthority force DKIM authority
      *
      * @return CreateResponse|array|ResponseInterface
      */
-    public function create(string $domain, string $smtpPass = null, string $spamAction = null, bool $wildcard = null)
+    public function create(string $domain, string $smtpPass = null, string $spamAction = null, bool $wildcard = null, bool $forceDkimAuthority = null)
     {
         Assert::stringNotEmpty($domain);
 
@@ -105,6 +106,12 @@ class Domain extends HttpApi
             Assert::boolean($wildcard);
 
             $params['wildcard'] = $wildcard ? 'true' : 'false';
+        }
+
+        if (null !== $forceDkimAuthority) {
+            Assert::boolean($forceDkimAuthority);
+
+            $params['force_dkim_authority'] = $forceDkimAuthority ? 'true' : 'false';
         }
 
         $response = $this->httpPost('/v3/domains', $params);

--- a/tests/Api/DomainTest.php
+++ b/tests/Api/DomainTest.php
@@ -129,6 +129,38 @@ JSON
         $api->create('example.com', 'foo', 'bar', true);
     }
 
+    public function testCreateWithPasswordForceDkimAuthority()
+    {
+        $this->setRequestMethod('POST');
+        $this->setRequestUri('/v3/domains');
+        $this->setRequestBody([
+            'name' => 'example.com',
+            'smtp_password' => 'foo',
+            'force_dkim_authority' => 'true',
+        ]);
+        $this->setHydrateClass(CreateResponse::class);
+
+        $api = $this->getApiInstance();
+        $api->create('example.com', 'foo', null, null, true);
+    }
+
+    public function testCreateWithPasswordSpamActionWildcardForceDkimAuthority()
+    {
+        $this->setRequestMethod('POST');
+        $this->setRequestUri('/v3/domains');
+        $this->setRequestBody([
+            'name' => 'example.com',
+            'smtp_password' => 'foo',
+            'spam_action' => 'bar',
+            'wildcard' => 'true',
+            'force_dkim_authority' => 'true',
+        ]);
+        $this->setHydrateClass(CreateResponse::class);
+
+        $api = $this->getApiInstance();
+        $api->create('example.com', 'foo', 'bar', true, true);
+    }
+
     public function testDelete()
     {
         $this->setRequestMethod('DELETE');


### PR DESCRIPTION
Added support for the force_dkim_authority parameter when adding/creating a new Mailgun domain.