### PR TITLE
Fix misspelled parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
     include:
         - php: 5.5
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" PREFER_COVERAGE=true
-        - php: hhvm
           dist: trusty
 
 install:

--- a/src/Mailgun/Api/Ip.php
+++ b/src/Mailgun/Api/Ip.php
@@ -53,7 +53,7 @@ class Ip extends HttpApi
     {
         Assert::stringNotEmpty($domain);
 
-        $response = $this->httpGet(sprintf('/v3/domains/%s/ip', $domain));
+        $response = $this->httpGet(sprintf('/v3/domains/%s/ips', $domain));
 
         return $this->hydrateResponse($response, IndexResponse::class);
     }

--- a/src/Mailgun/Api/Ip.php
+++ b/src/Mailgun/Api/Ip.php
@@ -88,7 +88,7 @@ class Ip extends HttpApi
         Assert::ip($ip);
 
         $params = [
-            'id' => $ip,
+            'ip' => $ip,
         ];
 
         $response = $this->httpPost(sprintf('/v3/domains/%s/ips', $domain), $params);


### PR DESCRIPTION
The ips()->assign() method fails because the required parameter is misspelled. This appears to be in all releases, not just the 2.x branch.