### PR TITLE
Fix assigning Ip

### DIFF
--- a/src/Api/Ip.php
+++ b/src/Api/Ip.php
@@ -81,7 +81,7 @@ class Ip extends HttpApi
         Assert::ip($ip);
 
         $params = [
-            'id' => $ip,
+            'ip' => $ip,
         ];
 
         $response = $this->httpPost(sprintf('/v3/domains/%s/ips', $domain), $params);

--- a/tests/Api/IpTest.php
+++ b/tests/Api/IpTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+namespace Mailgun\Tests\Api;
+
+use GuzzleHttp\Psr7\Response;
+use Mailgun\Api\Ip;
+use Mailgun\Model\Ip\UpdateResponse;
+
+class IpTest extends TestCase
+{
+    protected function getApiClass()
+    {
+        return Ip::class;
+    }
+
+    public function testAssign()
+    {
+        $this->setRequestMethod('POST');
+        $this->setRequestUri('/v3/domains/example.com/ips');
+        $this->setRequestBody([
+            'ip' => '127.0.0.1',
+        ]);
+        $this->setHydrateClass(UpdateResponse::class);
+
+        $api = $this->getApiInstance();
+        $api->assign('example.com', '127.0.0.1');
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in assigning an IP to a domain.

Assigning an IP to a domain currently results in the following error:

```
[Mailgun\Exception\HttpClientException] The parameters passed to the API were invalid. Check your inputs!

either 'ip' or 'pool_id' parameter is required, but not both in /var/www/vendor/mailgun/mailgun-php/src/Mailgun/Exception/HttpClientException.php on line 72
Stack Trace:
#0 /var/www/vendor/mailgun/mailgun-php/src/Mailgun/Api/HttpApi.php(91): Mailgun\Exception\HttpClientException::badRequest(Object(GuzzleHttp\Psr7\Response))
#1 /var/www/vendor/mailgun/mailgun-php/src/Mailgun/Api/HttpApi.php(73): Mailgun\Api\HttpApi->handleErrors(Object(GuzzleHttp\Psr7\Response))
#2 /var/www/vendor/mailgun/mailgun-php/src/Mailgun/Api/Ip.php(96): Mailgun\Api\HttpApi->hydrateResponse(Object(GuzzleHttp\Psr7\Response), 'Mailgun\\Model\\I...')
```

This happens because of a typo in `Ips::assign()` ('id' instead of 'ip'):

```
 public function assign(string $domain, string $ip)
    {
        Assert::stringNotEmpty($domain);
        Assert::ip($ip);

        $params = [
            'id' => $ip,
        ];

        $response = $this->httpPost(sprintf('/v3/domains/%s/ips', $domain), $params);

        return $this->hydrateResponse($response, UpdateResponse::class);
    }
```