### PR TITLE
Allow assigning a domain to a list of ips during creation

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -116,6 +116,7 @@ class Domain extends HttpApi
 
         if (null !== $ips) {
             Assert::isList($ips);
+            Assert::allString($ips);
 
             $params['ips'] = join(',', $ips);
         }

--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -74,15 +74,16 @@ class Domain extends HttpApi
      *
      * @see https://documentation.mailgun.com/en/latest/api-domains.html#domains
      *
-     * @param string $domain     name of the domain
-     * @param string $smtpPass   password for SMTP authentication
-     * @param string $spamAction `disable` or `tag` - inbound spam filtering
-     * @param bool   $wildcard   domain will accept email for subdomains
-     * @param bool   $forceDkimAuthority force DKIM authority
+     * @param string   $domain     name of the domain
+     * @param string   $smtpPass   password for SMTP authentication
+     * @param string   $spamAction `disable` or `tag` - inbound spam filtering
+     * @param bool     $wildcard   domain will accept email for subdomains
+     * @param bool     $forceDkimAuthority force DKIM authority
+     * @param string[] $ips        an array of ips to be assigned to the domain
      *
      * @return CreateResponse|array|ResponseInterface
      */
-    public function create(string $domain, string $smtpPass = null, string $spamAction = null, bool $wildcard = null, bool $forceDkimAuthority = null)
+    public function create(string $domain, string $smtpPass = null, string $spamAction = null, bool $wildcard = null, bool $forceDkimAuthority = null, ?array $ips = null)
     {
         Assert::stringNotEmpty($domain);
 
@@ -111,6 +112,12 @@ class Domain extends HttpApi
             Assert::boolean($forceDkimAuthority);
 
             $params['force_dkim_authority'] = $forceDkimAuthority ? 'true' : 'false';
+        }
+
+        if (null !== $ips) {
+            Assert::isList($ips);
+
+            $params['ips'] = join(',', $ips);
         }
 
         $response = $this->httpPost('/v3/domains', $params);

--- a/tests/Api/DomainTest.php
+++ b/tests/Api/DomainTest.php
@@ -241,4 +241,19 @@ JSON
         $api = $this->getApiInstance();
         $api->verify('example.com');
     }
+
+    public function testCreateWithIps()
+    {
+        $this->setRequestMethod('POST');
+        $this->setRequestUri('/v3/domains');
+        $this->setRequestBody([
+            'name' => 'example.com',
+            'smtp_password' => 'foo',
+            'ips' => "127.0.0.1,127.0.0.2",
+        ]);
+        $this->setHydrateClass(CreateResponse::class);
+
+        $api = $this->getApiInstance();
+        $api->create('example.com', 'foo', null, null, null, ["127.0.0.1", "127.0.0.2"]);
+    }
 }


### PR DESCRIPTION
The Domains API allows assigning Ips upon creation.
https://documentation.mailgun.com/en/latest/api-domains.html#domains

This PR adds that ability to the PHP SDK.