### PR TITLE
removed unused method

### DIFF
--- a/src/Api/Stats.php
+++ b/src/Api/Stats.php
@@ -33,16 +33,4 @@ class Stats extends HttpApi
 
         return $this->hydrateResponse($response, TotalResponse::class);
     }
-
-    /**
-     * @return AllResponse|array
-     */
-    public function all(string $domain, array $params = [])
-    {
-        Assert::stringNotEmpty($domain);
-
-        $response = $this->httpGet(sprintf('/v3/%s/stats', rawurlencode($domain)), $params);
-
-        return $this->hydrateResponse($response, AllResponse::class);
-    }
 }

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -53,31 +53,6 @@ class StatsTest extends TestCase
         $api->total('');
     }
 
-    public function testAll()
-    {
-        $data = [
-            'foo' => 'bar',
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('httpGet')
-            ->with('/v3/domain/stats', $data)
-            ->willReturn(new Response());
-
-        $api->all('domain', $data);
-    }
-
-    /**
-     * @expectedException \Mailgun\Exception\InvalidArgumentException
-     */
-    public function testAllInvalidArgument()
-    {
-        $api = $this->getApiMock();
-
-        $api->all('');
-    }
-
     public function totalProvider()
     {
         return [


### PR DESCRIPTION
https://github.com/mailgun/mailgun-php/issues/628 method all() is not working and has no endpoint associated with it

```
[05-Oct-2020 16:50:34 UTC] PHP Fatal error:  Uncaught Mailgun\Exception\HttpClientException: The endpoint you have tried to access does not exist. Check if the domain matches the domain you have configure on Mailgun. in /var/www/mailgun-php/src/Exception/HttpClientException.php:78
Stack trace:
#0 /var/www/mailgun-php/src/Api/HttpApi.php(91): Mailgun\Exception\HttpClientException::notFound(Object(GuzzleHttp\Psr7\Response))
#1 /var/www/mailgun-php/src/Api/HttpApi.php(67): Mailgun\Api\HttpApi->handleErrors(Object(GuzzleHttp\Psr7\Response))
#2 /var/www/mailgun-php/src/Api/Stats.php(46): Mailgun\Api\HttpApi->hydrateResponse(Object(GuzzleHttp\Psr7\Response), 'Mailgun\\Model\\S...')
#3 /var/www/mailgun-php-client/index.php(27): Mailgun\Api\Stats->all('sandbox152fb160...')
#4 {main}
  thrown in /var/www/mailgun-php/src/Exception/HttpClientException.php on line 78
```