### PR TITLE
Change Ip::index() default to return all ips instead of shared ips

### DIFF
--- a/src/Api/Ip.php
+++ b/src/Api/Ip.php
@@ -29,13 +29,13 @@ class Ip extends HttpApi
      *
      * @return IndexResponse|ResponseInterface
      */
-    public function index(bool $dedicated = false)
+    public function index(?bool $dedicated = null)
     {
-        Assert::boolean($dedicated);
-
-        $params = [
-            'dedicated' => $dedicated,
-        ];
+        $params = [];
+        if (null !== $dedicated) {
+            Assert::boolean($dedicated);
+            $params['dedicated'] = $dedicated;
+        }
 
         $response = $this->httpGet('/v3/ips', $params);
 

--- a/src/Model/Ip/IndexResponse.php
+++ b/src/Model/Ip/IndexResponse.php
@@ -28,6 +28,11 @@ final class IndexResponse implements ApiResponse
      */
     private $totalCount;
 
+    /**
+     * @var string[]
+     */
+   private $assignableToPools;
+
     private function __construct()
     {
     }
@@ -37,6 +42,7 @@ final class IndexResponse implements ApiResponse
         $model = new self();
         $model->items = $data['items'];
         $model->totalCount = $data['total_count'] ?? 0;
+        $model->assignableToPools = $data['assignable_to_pools'];
 
         return $model;
     }
@@ -47,6 +53,14 @@ final class IndexResponse implements ApiResponse
     public function getItems(): array
     {
         return $this->items;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAssignableToPools(): array
+    {
+        return $this->assignableToPools;
     }
 
     public function getTotalCount(): int

--- a/tests/Api/Ip.php
+++ b/tests/Api/Ip.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+namespace Mailgun\Tests\Api;
+
+use GuzzleHttp\Psr7\Response;
+use Mailgun\Api\Ip;
+use Mailgun\Model\Ip\IndexResponse;
+
+class IpTest extends TestCase
+{
+    protected function getApiClass()
+    {
+        return Ip::class;
+    }
+
+    public function testIndexAll()
+    {
+        $this->setRequestMethod('GET');
+        $this->setRequestUri('/v3/ips');
+        $this->setHttpResponse(new Response(200, ['Content-Type' => 'application/json'], <<<'JSON'
+{
+  "items": ["192.161.0.1", "192.168.0.2"],
+  "total_count": 2
+}
+JSON
+        ));
+
+        $api = $this->getApiInstance();
+        /** @var IndexResponse $response */
+        $response = $api->index(null);
+        $this->assertInstanceOf(IndexResponse::class, $response);
+        $this->assertEquals(2, $response->getTotalCount());
+        $this->assertEquals('192.161.0.1', $response->getItems()[0]);
+        $this->assertEquals('192.168.0.2', $response->getItems()[1]);
+    }
+    
+    public function testIndexOnlyDedicated()
+    {
+        $this->setRequestMethod('GET');
+        $this->setRequestUri('/v3/ips?dedicated=1');
+        $this->setHttpResponse(new Response(200, ['Content-Type' => 'application/json'], <<<'JSON'
+{
+  "items": ["192.161.0.1"],
+  "total_count": 1
+}
+JSON
+        ));
+
+        $api = $this->getApiInstance();
+        /** @var IndexResponse $response */
+        $response = $api->index(true);
+        $this->assertInstanceOf(IndexResponse::class, $response);
+        $this->assertEquals(1, $response->getTotalCount());
+        $this->assertEquals('192.161.0.1', $response->getItems()[0]);
+    }
+    
+    public function testIndexOnlyShared()
+    {
+        $this->setRequestMethod('GET');
+        $this->setRequestUri('/v3/ips?dedicated=0');
+        $this->setHttpResponse(new Response(200, ['Content-Type' => 'application/json'], <<<'JSON'
+{
+  "items": ["192.168.0.2"],
+  "total_count": 1
+}
+JSON
+        ));
+
+        $api = $this->getApiInstance();
+        /** @var IndexResponse $response */
+        $response = $api->index(false);
+        $this->assertInstanceOf(IndexResponse::class, $response);
+        $this->assertEquals(1, $response->getTotalCount());
+        $this->assertEquals('192.168.0.2', $response->getItems()[0]);
+    }
+}

--- a/tests/Api/Ip.php
+++ b/tests/Api/Ip.php
@@ -28,6 +28,7 @@ class IpTest extends TestCase
         $this->setRequestUri('/v3/ips');
         $this->setHttpResponse(new Response(200, ['Content-Type' => 'application/json'], <<<'JSON'
 {
+  "assignable_to_pools": ["192.168.0.1"],
   "items": ["192.161.0.1", "192.168.0.2"],
   "total_count": 2
 }
@@ -41,6 +42,7 @@ JSON
         $this->assertEquals(2, $response->getTotalCount());
         $this->assertEquals('192.161.0.1', $response->getItems()[0]);
         $this->assertEquals('192.168.0.2', $response->getItems()[1]);
+        $this->assertEquals('192.168.0.1', $response->getAssignableToPools()[0]);
     }
     
     public function testIndexOnlyDedicated()
@@ -49,6 +51,7 @@ JSON
         $this->setRequestUri('/v3/ips?dedicated=1');
         $this->setHttpResponse(new Response(200, ['Content-Type' => 'application/json'], <<<'JSON'
 {
+  "assignable_to_pools": ["192.168.0.1"],
   "items": ["192.161.0.1"],
   "total_count": 1
 }
@@ -61,6 +64,7 @@ JSON
         $this->assertInstanceOf(IndexResponse::class, $response);
         $this->assertEquals(1, $response->getTotalCount());
         $this->assertEquals('192.161.0.1', $response->getItems()[0]);
+        $this->assertEquals('192.168.0.1', $response->getAssignableToPools()[0]);
     }
     
     public function testIndexOnlyShared()
@@ -69,6 +73,7 @@ JSON
         $this->setRequestUri('/v3/ips?dedicated=0');
         $this->setHttpResponse(new Response(200, ['Content-Type' => 'application/json'], <<<'JSON'
 {
+  "assignable_to_pools": ["192.168.0.1"],
   "items": ["192.168.0.2"],
   "total_count": 1
 }
@@ -81,5 +86,6 @@ JSON
         $this->assertInstanceOf(IndexResponse::class, $response);
         $this->assertEquals(1, $response->getTotalCount());
         $this->assertEquals('192.168.0.2', $response->getItems()[0]);
+        $this->assertEquals('192.168.0.1', $response->getAssignableToPools()[0]);
     }
 }

--- a/tests/Model/Ip/IndexResponseTest.php
+++ b/tests/Model/Ip/IndexResponseTest.php
@@ -21,6 +21,7 @@ class IndexResponseTest extends BaseModelTest
         $json =
 <<<'JSON'
 {
+  "assignable_to_pools": ["192.161.0.1"],
   "items": ["192.161.0.1", "192.168.0.2"],
   "total_count": 2
 }
@@ -30,5 +31,21 @@ JSON;
         $items = $model->getItems();
         $this->assertCount(2, $items);
         $this->assertEquals('192.161.0.1', $items[0]);
+    }
+
+    public function testCreateWithAssignableToPools()
+    {
+        $json =
+<<<'JSON'
+{
+  "assignable_to_pools": ["192.161.0.1"],
+  "items": ["192.161.0.1", "192.168.0.2"],
+  "total_count": 2
+}
+JSON;
+        $model = IndexResponse::create(json_decode($json, true));
+        $assignableToPools = $model->getAssignableToPools();
+        $this->assertCount(1, $assignableToPools);
+        $this->assertEquals('192.161.0.1', $assignableToPools[0]);
     }
 }


### PR DESCRIPTION
The GET /ips endpoint returns all IPs by default, shared ips if the dedicated parameter is false and dedicated ips only if the dedicated parameter is true. However, the SDK `Ip::index()` method always defaults to passing false, and has no ability to return all ips.

This PR fixes that so the default behavior for `Ip::index()` is to return all IPs (instead of shared IPs). This is more consistent with the API.