### PR TITLE
PHP 8.x support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
             matrix:
                 # https://github.com/marketplace/actions/setup-php-action#github-hosted-runners
                 operating-system: [ 'ubuntu-18.04' ]
-                php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+                php-versions: [ '7.3', '7.4', '8.0' ]
 
         runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             matrix:
                 # https://github.com/marketplace/actions/setup-php-action#github-hosted-runners
-                operating-system: [ 'ubuntu-18.04' ]
+                operating-system: [ 'ubuntu-latest' ]
                 php-versions: [ '7.3', '7.4', '8.0' ]
 
         runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ 'ubuntu-latest' ]
-                php-versions: [ '7.1', '7.2', '7.3', '7.4' ]
+                php-versions: [ '7.3', '7.4', '8.0' ]
 
         runs-on: ${{ matrix.operating-system }}
 
@@ -37,13 +37,13 @@ jobs:
               run: composer test
 
             - name: PHP Stan
-              if: matrix.php-versions == '7.1'
+              if: matrix.php-versions == '7.3'
               run: |
                   phpstan --version
                   phpstan analyse
 
             - name: Scrunitizer CI
-              if: matrix.php-versions == '7.1'
+              if: matrix.php-versions == '7.3'
               run: |
                   wget https://scrutinizer-ci.com/ocular.phar
                   php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
             matrix:
                 # https://github.com/marketplace/actions/setup-php-action#github-hosted-runners
                 operating-system: [ 'ubuntu-18.04' ]
-                php-versions: [ '7.3', '7.4', '8.0' ]
+                php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
 
         runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,8 @@ jobs:
 
         strategy:
             matrix:
-                operating-system: [ 'ubuntu-latest' ]
+                # https://github.com/marketplace/actions/setup-php-action#github-hosted-runners
+                operating-system: [ 'ubuntu-18.04' ]
                 php-versions: [ '7.3', '7.4', '8.0' ]
 
         runs-on: ${{ matrix.operating-system }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 phpunit.phar
 phpunit.xml
 modd.conf
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## [Unreleased]
+
+### Added
+
+- Support for PHP 8.x
+
+### Removed
+
+- Support for PHP 7.1 and 7.2 as they both have reached their end of life
+
 ## 3.2.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,17 @@
     "description": "The Mailgun SDK provides methods for all API functions.",
     "require": {
         "php": "^7.3 || ^8.0",
-        "psr/http-client": "^1.0,>=1.0.1",
-        "php-http/multipart-stream-builder": "^1.0,>=1.1.2",
-        "php-http/client-common": "^2.2,>=2.2.1",
-        "php-http/discovery": "^1.9,>=1.9.1",
-        "webmozart/assert": "^1.9,>=1.9.1"
+        "psr/http-client": "^1.0.1",
+        "php-http/multipart-stream-builder": "^1.1.2",
+        "php-http/client-common": "^2.2.1",
+        "php-http/discovery": "^1.9.1",
+        "webmozart/assert": "^1.9.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",
-        "php-http/guzzle7-adapter": "^0.1,>=0.1.1",
-        "nyholm/psr7": "^1.3,>=1.3.1",
-        "nyholm/nsa": "^1.2,>=1.2.1"
+        "php-http/guzzle7-adapter": "^0.1.1",
+        "nyholm/psr7": "^1.3.1",
+        "nyholm/nsa": "^1.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,18 +2,18 @@
     "name": "mailgun/mailgun-php",
     "description": "The Mailgun SDK provides methods for all API functions.",
     "require": {
-        "php": "^7.1",
-        "psr/http-client": "^1.0",
-        "php-http/multipart-stream-builder": "^1.0",
-        "php-http/client-common": "^1.9 || ^2.0",
-        "php-http/discovery": "^1.6",
-        "webmozart/assert": "^1.6"
+        "php": "^7.3 || ^8.0",
+        "psr/http-client": "^1.0,>=1.0.1",
+        "php-http/multipart-stream-builder": "^1.0,>=1.1.2",
+        "php-http/client-common": "^2.2,>=2.2.1",
+        "php-http/discovery": "^1.9,>=1.9.1",
+        "webmozart/assert": "^1.9,>=1.9.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
-        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
-        "nyholm/psr7": "^1.0",
-        "nyholm/nsa": "^1.1"
+        "phpunit/phpunit": "^9.3",
+        "php-http/guzzle7-adapter": "^0.1,>=0.1.1",
+        "nyholm/psr7": "^1.3,>=1.3.1",
+        "nyholm/nsa": "^1.2,>=1.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Mailgun\Tests\Api;
 
 use GuzzleHttp\Psr7\Response;
+use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Hydrator\ModelHydrator;
 use Mailgun\Model\Stats\TotalResponse;
 use Mailgun\Model\Stats\TotalResponseItem;
@@ -44,11 +45,10 @@ class StatsTest extends TestCase
         $this->assertContainsOnlyInstancesOf(TotalResponseItem::class, $total->getStats());
     }
 
-    /**
-     * @expectedException \Mailgun\Exception\InvalidArgumentException
-     */
     public function testTotalInvalidArgument()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $api = $this->getApiMock();
         $api->total('');
     }

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -37,7 +37,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     private $hydrateClass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->reset();
     }

--- a/tests/HttpClient/RequestBuilderTest.php
+++ b/tests/HttpClient/RequestBuilderTest.php
@@ -40,7 +40,7 @@ class RequestBuilderTest extends MailgunTestCase
     /**
      * Environment preset.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -61,7 +61,7 @@ class RequestBuilderTest extends MailgunTestCase
     /**
      * Environment reset.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Message/BatchMessageTest.php
+++ b/tests/Message/BatchMessageTest.php
@@ -25,7 +25,7 @@ class BatchMessageTest extends MailgunTestCase
      */
     private $batchMessage;
 
-    public function setUp()
+    public function setUp(): void
     {
         $messageApi = $this->getMockBuilder(Message::class)
             ->disableOriginalConstructor()

--- a/tests/Message/MessageBuilderTest.php
+++ b/tests/Message/MessageBuilderTest.php
@@ -22,7 +22,7 @@ class MessageBuilderTest extends MailgunTestCase
      */
     private $messageBuilder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->messageBuilder = new MessageBuilder();
     }


### PR DESCRIPTION
Closes #725

----

Before merging this new PR, we will wait for https://github.com/mailgun/mailgun-php/pull/726 to be merged so we can provide a new SDK version with the highly requested Email Validator feature.

This PR to enable PHP 8.0 support causes a BC Break so that it will be flagged as SDK 4.0.0