### PR TITLE
Add additional events to TotalResponseItem

### DIFF
--- a/src/Model/Stats/TotalResponseItem.php
+++ b/src/Model/Stats/TotalResponseItem.php
@@ -21,6 +21,10 @@ final class TotalResponseItem
     private $delivered;
     private $failed;
     private $complained;
+    private $opened;
+    private $clicked;
+    private $unsubscribed;
+    private $stored;
 
     public static function create(array $data): self
     {
@@ -30,6 +34,10 @@ final class TotalResponseItem
         $model->delivered = $data['delivered'] ?? [];
         $model->failed = $data['failed'] ?? [];
         $model->complained = $data['complained'] ?? [];
+        $model->opened = $data['opened'] ?? [];
+        $model->clicked = $data['clicked'] ?? [];
+        $model->unsubscribed = $data['unsubscribed'] ?? [];
+        $model->stored = $data['stored'] ?? [];
 
         return $model;
     }
@@ -61,5 +69,25 @@ final class TotalResponseItem
     public function getComplained(): array
     {
         return $this->complained;
+    }
+
+    public function getOpened(): array
+    {
+        return $this->opened;
+    }
+
+    public function getClicked(): array
+    {
+        return $this->clicked;
+    }
+
+    public function getUnsubscribed(): array
+    {
+        return $this->unsubscribed;
+    }
+
+    public function getStored(): array
+    {
+        return $this->stored;
     }
 }

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -42,6 +42,22 @@ class StatsTest extends TestCase
         $this->assertInstanceOf(TotalResponse::class, $total);
         $this->assertCount(count($responseData['stats']), $total->getStats());
         $this->assertContainsOnlyInstancesOf(TotalResponseItem::class, $total->getStats());
+
+        $event = $queryParameters['event'];
+        $responseStat = $total->getStats()[0];
+        $statGetter = 'get'.ucwords($event);
+
+        if ('failed' !== $event) {
+            $expectedTotal = $responseData['stats'][0][$event]['total'];
+            $actualTotal = $responseStat->$statGetter()['total'];
+        }
+
+        if ('failed' == $event) {
+            $expectedTotal = $responseData['stats'][0][$event]['permanent']['total'];
+            $actualTotal = $responseStat->$statGetter()['permanent']['total'];
+        }
+
+        $this->assertEquals($expectedTotal, $actualTotal);
     }
 
     /**
@@ -56,36 +72,36 @@ class StatsTest extends TestCase
     public function totalProvider()
     {
         return [
-            'accepted events' => [
+            'accepted events'  => [
                 'queryParameters' => [
                     'event' => 'accepted',
                 ],
-                'responseData' => $this->generateTotalResponsePayload([
+                'responseData'    => $this->generateTotalResponsePayload([
                     [
-                        'time' => $this->formatDate('-7 days'),
+                        'time'     => $this->formatDate('-7 days'),
                         'accepted' => [
                             'outgoing' => 10,
                             'incoming' => 5,
-                            'total' => 15,
+                            'total'    => 15,
                         ],
                     ],
                 ]),
             ],
-            'failed events' => [
+            'failed events'    => [
                 'queryParameters' => [
                     'event' => 'failed',
                 ],
-                'responseData' => $this->generateTotalResponsePayload([
+                'responseData'    => $this->generateTotalResponsePayload([
                     [
-                        'time' => $this->formatDate('-7 days'),
+                        'time'   => $this->formatDate('-7 days'),
                         'failed' => [
                             'permanent' => [
-                                'bounce' => 4,
-                                'delayed-bounce' => 1,
-                                'suppress-bounce' => 1,
+                                'bounce'               => 4,
+                                'delayed-bounce'       => 1,
+                                'suppress-bounce'      => 1,
                                 'suppress-unsubscribe' => 2,
-                                'suppress-complaint' => 3,
-                                'total' => 10,
+                                'suppress-complaint'   => 3,
+                                'total'                => 10,
                             ],
                             'temporary' => [
                                 'espblock' => 1,
@@ -98,13 +114,39 @@ class StatsTest extends TestCase
                 'queryParameters' => [
                     'event' => 'delivered',
                 ],
-                'responseData' => $this->generateTotalResponsePayload([
+                'responseData'    => $this->generateTotalResponsePayload([
                     [
-                        'time' => $this->formatDate('-7 days'),
+                        'time'      => $this->formatDate('-7 days'),
                         'delivered' => [
-                            'smtp' => 15,
-                            'http' => 5,
+                            'smtp'  => 15,
+                            'http'  => 5,
                             'total' => 20,
+                        ],
+                    ],
+                ]),
+            ],
+            'clicked events'   => [
+                'queryParameters' => [
+                    'event' => 'clicked',
+                ],
+                'responseData'    => $this->generateTotalResponsePayload([
+                    [
+                        'time'    => $this->formatDate('-7 days'),
+                        'clicked' => [
+                            'total' => 7,
+                        ],
+                    ],
+                ]),
+            ],
+            'opened events'   => [
+                'queryParameters' => [
+                    'event' => 'opened',
+                ],
+                'responseData'    => $this->generateTotalResponsePayload([
+                    [
+                        'time'    => $this->formatDate('-7 days'),
+                        'opened' => [
+                            'total' => 19,
                         ],
                     ],
                 ]),
@@ -115,10 +157,10 @@ class StatsTest extends TestCase
     private function generateTotalResponsePayload(array $stats, $start = '-7 days', $end = 'now', $resolution = 'day')
     {
         return [
-            'end' => $this->formatDate($end),
+            'end'        => $this->formatDate($end),
             'resolution' => $resolution,
-            'start' => $this->formatDate($start),
-            'stats' => $stats,
+            'start'      => $this->formatDate($start),
+            'stats'      => $stats,
         ];
     }
 


### PR DESCRIPTION
Currently the TotalResponseItem class does not parse opened, clicked, unsubscribed, and stored events.
This PR solves that.

It also adds tests for the new events, and adds testing of totals in the response