### PR TITLE
Add additional events to TotalResponseItem

### DIFF
--- a/src/Model/Stats/TotalResponseItem.php
+++ b/src/Model/Stats/TotalResponseItem.php
@@ -21,6 +21,10 @@ final class TotalResponseItem
     private $delivered;
     private $failed;
     private $complained;
+    private $opened;
+    private $clicked;
+    private $unsubscribed;
+    private $stored;
 
     public static function create(array $data): self
     {
@@ -30,6 +34,10 @@ final class TotalResponseItem
         $model->delivered = $data['delivered'] ?? [];
         $model->failed = $data['failed'] ?? [];
         $model->complained = $data['complained'] ?? [];
+        $model->opened = $data['opened'] ?? [];
+        $model->clicked = $data['clicked'] ?? [];
+        $model->unsubscribed = $data['unsubscribed'] ?? [];
+        $model->stored = $data['stored'] ?? [];
 
         return $model;
     }
@@ -61,5 +69,25 @@ final class TotalResponseItem
     public function getComplained(): array
     {
         return $this->complained;
+    }
+
+    public function getOpened(): array
+    {
+        return $this->opened;
+    }
+
+    public function getClicked(): array
+    {
+        return $this->clicked;
+    }
+
+    public function getUnsubscribed(): array
+    {
+        return $this->unsubscribed;
+    }
+
+    public function getStored(): array
+    {
+        return $this->stored;
     }
 }

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -42,6 +42,22 @@ class StatsTest extends TestCase
         $this->assertInstanceOf(TotalResponse::class, $total);
         $this->assertCount(count($responseData['stats']), $total->getStats());
         $this->assertContainsOnlyInstancesOf(TotalResponseItem::class, $total->getStats());
+
+        $event = $queryParameters['event'];
+        $responseStat = $total->getStats()[0];
+        $statGetter = 'get'.ucwords($event);
+
+        if ('failed' !== $event) {
+            $expectedTotal = $responseData['stats'][0][$event]['total'];
+            $actualTotal = $responseStat->$statGetter()['total'];
+        }
+
+        if ('failed' === $event) {
+            $expectedTotal = $responseData['stats'][0][$event]['permanent']['total'];
+            $actualTotal = $responseStat->$statGetter()['permanent']['total'];
+        }
+
+        $this->assertEquals($expectedTotal, $actualTotal);
     }
 
     /**
@@ -105,6 +121,58 @@ class StatsTest extends TestCase
                             'smtp' => 15,
                             'http' => 5,
                             'total' => 20,
+                        ],
+                    ],
+                ]),
+            ],
+            'clicked events' => [
+                'queryParameters' => [
+                    'event' => 'clicked',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'clicked' => [
+                            'total' => 7,
+                        ],
+                    ],
+                ]),
+            ],
+            'opened events' => [
+                'queryParameters' => [
+                    'event' => 'opened',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'opened' => [
+                            'total' => 19,
+                        ],
+                    ],
+                ]),
+            ],
+            'unsubscribed events' => [
+                'queryParameters' => [
+                    'event' => 'unsubscribed',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'unsubscribed' => [
+                            'total' => 10,
+                        ],
+                    ],
+                ]),
+            ],
+            'stored events' => [
+                'queryParameters' => [
+                    'event' => 'stored',
+                ],
+                'responseData' => $this->generateTotalResponsePayload([
+                    [
+                        'time' => $this->formatDate('-7 days'),
+                        'stored' => [
+                            'total' => 12,
                         ],
                     ],
                 ]),


### PR DESCRIPTION
Currently the TotalResponseItem class does not parse opened, clicked, unsubscribed, and stored events.
This PR solves that.

It also adds tests for the new events, and adds testing of totals in the response