### PR TITLE
Allow for pagination over members in a mailinglist

### DIFF
--- a/src/Api/MailingList/Member.php
+++ b/src/Api/MailingList/Member.php
@@ -32,6 +32,7 @@ class Member extends HttpApi
      * @param string    $address    Address of the mailing list
      * @param int       $limit      Maximum number of records to return (optional: 100 by default)
      * @param bool|null $subscribed `true` to lists subscribed, `false` for unsubscribed. list all if null
+     * @param array     $params     Array with additional params to add to the request
      *
      * @return IndexResponse
      *

--- a/src/Api/MailingList/Member.php
+++ b/src/Api/MailingList/Member.php
@@ -37,14 +37,12 @@ class Member extends HttpApi
      *
      * @throws \Exception
      */
-    public function index(string $address, int $limit = 100, bool $subscribed = null)
+    public function index(string $address, int $limit = 100, bool $subscribed = null, array $params = [])
     {
         Assert::stringNotEmpty($address);
         Assert::greaterThan($limit, 0);
 
-        $params = [
-            'limit' => $limit,
-        ];
+        $params['limit'] = $limit;
 
         if (true === $subscribed) {
             $params['subscribed'] = 'yes';


### PR DESCRIPTION
The current Mailgun PHP SDK does not support pagination over the members in a mailinglist, at least IMHO. By adding a params array to the index function one can add "page" and "address" params to the request to paginate over the resuts.