### PR TITLE
Fix PHPStan error reported for ModelHydrator::hydrate (and tighten $class param type for all hydrator classes)

### DIFF
--- a/src/Api/HttpApi.php
+++ b/src/Api/HttpApi.php
@@ -48,7 +48,7 @@ abstract class HttpApi
     {
         if (!is_a($httpClient, ClientInterface::class) &&
             !is_a($httpClient, PluginClient::class)) {
-            throw new \RuntimeException('httpClient must be an instance of 
+            throw new \RuntimeException('httpClient must be an instance of
             Psr\Http\Client\ClientInterface or Http\Client\Common\PluginClient');
         }
         $this->httpClient = $httpClient;
@@ -59,7 +59,7 @@ abstract class HttpApi
     }
 
     /**
-     * @phpstan-param class-string $class
+     * @param class-string $class
      *
      * @return mixed|ResponseInterface
      *

--- a/src/Api/HttpApi.php
+++ b/src/Api/HttpApi.php
@@ -59,6 +59,8 @@ abstract class HttpApi
     }
 
     /**
+     * @phpstan-param class-string $class
+     *
      * @return mixed|ResponseInterface
      *
      * @throws \Exception

--- a/src/Api/Pagination.php
+++ b/src/Api/Pagination.php
@@ -23,7 +23,7 @@ trait Pagination
     abstract protected function httpGet(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface;
 
     /**
-     * @phpstan-param class-string $className
+     * @param class-string $className
      */
     abstract protected function hydrateResponse(ResponseInterface $response, string $className);
 
@@ -48,7 +48,7 @@ trait Pagination
     }
 
     /**
-     * @phpstan-param class-string $class
+     * @param class-string $class
      */
     private function getPaginationUrl(string $url, string $class): ?PagingProvider
     {

--- a/src/Api/Pagination.php
+++ b/src/Api/Pagination.php
@@ -22,6 +22,9 @@ trait Pagination
 {
     abstract protected function httpGet(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface;
 
+    /**
+     * @phpstan-param class-string $className
+     */
     abstract protected function hydrateResponse(ResponseInterface $response, string $className);
 
     public function nextPage(PagingProvider $response): ?PagingProvider
@@ -44,6 +47,9 @@ trait Pagination
         return $this->getPaginationUrl($response->getLastUrl(), get_class($response));
     }
 
+    /**
+     * @phpstan-param class-string $class
+     */
     private function getPaginationUrl(string $url, string $class): ?PagingProvider
     {
         Assert::stringNotEmpty($class);

--- a/src/Hydrator/ArrayHydrator.php
+++ b/src/Hydrator/ArrayHydrator.php
@@ -22,7 +22,7 @@ use Psr\Http\Message\ResponseInterface;
 final class ArrayHydrator implements Hydrator
 {
     /**
-     * @phpstan-param class-string $class
+     * @param class-string $class
      *
      * @return array
      */

--- a/src/Hydrator/ArrayHydrator.php
+++ b/src/Hydrator/ArrayHydrator.php
@@ -22,6 +22,8 @@ use Psr\Http\Message\ResponseInterface;
 final class ArrayHydrator implements Hydrator
 {
     /**
+     * @phpstan-param class-string $class
+     *
      * @return array
      */
     public function hydrate(ResponseInterface $response, string $class)

--- a/src/Hydrator/Hydrator.php
+++ b/src/Hydrator/Hydrator.php
@@ -20,6 +20,8 @@ use Psr\Http\Message\ResponseInterface;
 interface Hydrator
 {
     /**
+     * @phpstan-param class-string $class
+     *
      * @throws HydrationException
      */
     public function hydrate(ResponseInterface $response, string $class);

--- a/src/Hydrator/Hydrator.php
+++ b/src/Hydrator/Hydrator.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 interface Hydrator
 {
     /**
-     * @phpstan-param class-string $class
+     * @param class-string $class
      *
      * @throws HydrationException
      */

--- a/src/Hydrator/ModelHydrator.php
+++ b/src/Hydrator/ModelHydrator.php
@@ -23,6 +23,8 @@ use Psr\Http\Message\ResponseInterface;
 final class ModelHydrator implements Hydrator
 {
     /**
+     * @phpstan-param class-string $class
+     *
      * @return ResponseInterface
      */
     public function hydrate(ResponseInterface $response, string $class)
@@ -41,7 +43,7 @@ final class ModelHydrator implements Hydrator
         }
 
         if (is_subclass_of($class, ApiResponse::class)) {
-            $object = call_user_func($class.'::create', $data);
+            $object = call_user_func([$class, 'create'], $data);
         } else {
             $object = new $class($data);
         }

--- a/src/Hydrator/ModelHydrator.php
+++ b/src/Hydrator/ModelHydrator.php
@@ -23,7 +23,7 @@ use Psr\Http\Message\ResponseInterface;
 final class ModelHydrator implements Hydrator
 {
     /**
-     * @phpstan-param class-string $class
+     * @param class-string $class
      *
      * @return ResponseInterface
      */

--- a/src/Hydrator/NoopHydrator.php
+++ b/src/Hydrator/NoopHydrator.php
@@ -21,7 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 final class NoopHydrator implements Hydrator
 {
     /**
-     * @phpstan-param class-string $class
+     * @param class-string $class
      *
      * @throws \LogicException
      */

--- a/src/Hydrator/NoopHydrator.php
+++ b/src/Hydrator/NoopHydrator.php
@@ -21,6 +21,8 @@ use Psr\Http\Message\ResponseInterface;
 final class NoopHydrator implements Hydrator
 {
     /**
+     * @phpstan-param class-string $class
+     *
      * @throws \LogicException
      */
     public function hydrate(ResponseInterface $response, string $class)


### PR DESCRIPTION
This is just a simple little PR that addresses the following message you get when you run PHPStan's static analysis on the project:

```
 ------ ------------------------------------------------------------------------------------------------------ 
  Line   Hydrator/ModelHydrator.php                                                                            
 ------ ------------------------------------------------------------------------------------------------------ 
  45     Parameter #1 $callback of function call_user_func expects callable(): mixed, non-empty-string given.  
 ------ ------------------------------------------------------------------------------------------------------
```

![image](https://user-images.githubusercontent.com/19592990/128293889-45651967-b41a-4a7d-8c6d-bbd6bdf024f3.png)

The fix just changes the `callable` to use the array syntax for static methods seen in the [official PHP docs](https://www.php.net/manual/en/language.types.callable.php).

I also added an additional PHPStan [`class-string`](https://phpstan.org/writing-php-code/phpdoc-types#class-string) type annotation to make it clearer for PHPStan users that the function expects class name strings.
