### PR TITLE
Update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "require-dev": {
         "nyholm/nsa": "^1.2.1",
         "nyholm/psr7": "^1.3.1",
-        "php-http/guzzle7-adapter": "^0.1.1",
+        "symfony/http-client": "^5.3",
         "phpunit/phpunit": "^9.3"
     },
     "suggest": {
-        "guzzlehttp/psr7": "PSR-7 message implementation that also provides common utility methods",
-        "php-http/curl-client": "cURL client for PHP-HTTP"
+        "nyholm/psr7": "PSR-7 message implementation",
+        "symfony/http-client": "HTTP client"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require-dev": {
         "nyholm/nsa": "^1.2.1",
         "nyholm/psr7": "^1.3.1",
-        "symfony/http-client": "^5.3",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "symfony/http-client": "^5.3"
     },
     "suggest": {
         "nyholm/psr7": "PSR-7 message implementation",

--- a/tests/Api/DomainTest.php
+++ b/tests/Api/DomainTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\Domain;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Model\Domain\ConnectionResponse;
@@ -28,6 +27,7 @@ use Mailgun\Model\Domain\UpdateCredentialResponse;
 use Mailgun\Model\Domain\UpdateOpenTrackingResponse;
 use Mailgun\Model\Domain\UpdateUnsubscribeTrackingResponse;
 use Mailgun\Model\Domain\VerifyResponse;
+use Nyholm\Psr7\Response;
 
 class DomainTest extends TestCase
 {

--- a/tests/Api/DomainTest.php
+++ b/tests/Api/DomainTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\Domain;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Model\Domain\ConnectionResponse;

--- a/tests/Api/EmailValidationTest.php
+++ b/tests/Api/EmailValidationTest.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\EmailValidation;
+use Nyholm\Psr7\Response;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>

--- a/tests/Api/EmailValidationTest.php
+++ b/tests/Api/EmailValidationTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\EmailValidation;
 
 /**

--- a/tests/Api/EmailValidationV4Test.php
+++ b/tests/Api/EmailValidationV4Test.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\EmailValidationV4;
 use Mailgun\Model\EmailValidationV4\CreateBulkJobResponse;
 use Mailgun\Model\EmailValidationV4\CreateBulkPreviewResponse;
@@ -26,6 +25,7 @@ use Mailgun\Model\EmailValidationV4\Preview;
 use Mailgun\Model\EmailValidationV4\PromoteBulkPreviewResponse;
 use Mailgun\Model\EmailValidationV4\Summary;
 use Mailgun\Model\EmailValidationV4\ValidateResponse;
+use Nyholm\Psr7\Response;
 
 class EmailValidationV4Test extends TestCase
 {

--- a/tests/Api/EmailValidationV4Test.php
+++ b/tests/Api/EmailValidationV4Test.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\EmailValidationV4;
 use Mailgun\Model\EmailValidationV4\CreateBulkJobResponse;
 use Mailgun\Model\EmailValidationV4\CreateBulkPreviewResponse;

--- a/tests/Api/EventTest.php
+++ b/tests/Api/EventTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\Event;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Model\Event\EventResponse;
+use Nyholm\Psr7\Response;
 
 class EventTest extends TestCase
 {

--- a/tests/Api/EventTest.php
+++ b/tests/Api/EventTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\Event;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Model\Event\EventResponse;

--- a/tests/Api/Ip.php
+++ b/tests/Api/Ip.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\Ip;
 use Mailgun\Model\Ip\IndexResponse;
+use Nyholm\Psr7\Response;
 
 class IpTest extends TestCase
 {

--- a/tests/Api/Ip.php
+++ b/tests/Api/Ip.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\Ip;
 use Mailgun\Model\Ip\IndexResponse;
 

--- a/tests/Api/MailingList/MemberTest.php
+++ b/tests/Api/MailingList/MemberTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api\MailingList;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\MailingList;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Tests\Api\TestCase;

--- a/tests/Api/MailingList/MemberTest.php
+++ b/tests/Api/MailingList/MemberTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api\MailingList;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\MailingList;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Tests\Api\TestCase;
+use Nyholm\Psr7\Response;
 
 class MemberTest extends TestCase
 {

--- a/tests/Api/MailingListTest.php
+++ b/tests/Api/MailingListTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\MailingList;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Model\EmailValidation\ValidateResponse;
 use Mailgun\Model\MailingList\ValidationCancelResponse;
 use Mailgun\Model\MailingList\ValidationStatusResponse;
+use Nyholm\Psr7\Response;
 
 class MailingListTest extends TestCase
 {

--- a/tests/Api/MailingListTest.php
+++ b/tests/Api/MailingListTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\MailingList;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Model\EmailValidation\ValidateResponse;

--- a/tests/Api/MessageTest.php
+++ b/tests/Api/MessageTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\Message;
 use Mailgun\Model\Message\SendResponse;
 use Mailgun\Model\Message\ShowResponse;
+use Nyholm\Psr7\Response;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/tests/Api/MessageTest.php
+++ b/tests/Api/MessageTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\Message;
 use Mailgun\Model\Message\SendResponse;
 use Mailgun\Model\Message\ShowResponse;

--- a/tests/Api/RouteTest.php
+++ b/tests/Api/RouteTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\Route;
 use Mailgun\Model\Route\DeleteResponse;
 use Mailgun\Model\Route\IndexResponse;
 use Mailgun\Model\Route\ShowResponse;
 use Mailgun\Model\Route\UpdateResponse;
+use Nyholm\Psr7\Response;
 
 /**
  * @author David Garcia <me@davidgarcia.cat>

--- a/tests/Api/RouteTest.php
+++ b/tests/Api/RouteTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\Route;
 use Mailgun\Model\Route\DeleteResponse;
 use Mailgun\Model\Route\IndexResponse;

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Hydrator\ModelHydrator;
 use Mailgun\Model\Stats\TotalResponse;

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Hydrator\ModelHydrator;
 use Mailgun\Model\Stats\TotalResponse;
 use Mailgun\Model\Stats\TotalResponseItem;
+use Nyholm\Psr7\Response;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/tests/Api/TagTest.php
+++ b/tests/Api/TagTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Api\Tag;
 use Mailgun\Hydrator\ModelHydrator;
 use Mailgun\Model\Tag\IndexResponse;

--- a/tests/Api/TagTest.php
+++ b/tests/Api/TagTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Api\Tag;
 use Mailgun\Hydrator\ModelHydrator;
 use Mailgun\Model\Tag\IndexResponse;
+use Nyholm\Psr7\Response;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
 use Mailgun\Hydrator\ModelHydrator;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Api;
 
+use Mailgun\Hydrator\ModelHydrator;
 use Nyholm\Psr7\Request;
 use Nyholm\Psr7\Response;
-use Mailgun\Hydrator\ModelHydrator;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/Exception/HttpClientExceptionTest.php
+++ b/tests/Exception/HttpClientExceptionTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Exception;
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Mailgun\Exception\HttpClientException;
 use Mailgun\Tests\MailgunTestCase;
 

--- a/tests/Exception/HttpClientExceptionTest.php
+++ b/tests/Exception/HttpClientExceptionTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Mailgun\Tests\Exception;
 
-use Nyholm\Psr7\Response;
 use Mailgun\Exception\HttpClientException;
 use Mailgun\Tests\MailgunTestCase;
+use Nyholm\Psr7\Response;
 
 class HttpClientExceptionTest extends MailgunTestCase
 {


### PR DESCRIPTION
The `php-http/guzzle7-adapter` is not needed anymore. We can use guzzle or symfony's http client instead. 


Disclaimer: I maintain all three packages. 