### PR TITLE
Add template support when using BatchMessage

### DIFF
--- a/src/Message/BatchMessage.php
+++ b/src/Message/BatchMessage.php
@@ -115,7 +115,7 @@ class BatchMessage extends MessageBuilder
         }
 
         if (empty($message['text']) && empty($message['html']) && empty($message['template'])) {
-            throw MissingRequiredParameter::create('text", "html" or "template"');
+            throw MissingRequiredParameter::create('text", "html" or "template');
         }
 
         $message['recipient-variables'] = json_encode($this->batchRecipientAttributes);

--- a/src/Message/BatchMessage.php
+++ b/src/Message/BatchMessage.php
@@ -114,8 +114,8 @@ class BatchMessage extends MessageBuilder
             throw MissingRequiredParameter::create('subject');
         }
 
-        if (empty($message['text']) && empty($message['html'])) {
-            throw MissingRequiredParameter::create('text" or "html');
+        if (empty($message['text']) && empty($message['html']) && empty($message['template'])) {
+            throw MissingRequiredParameter::create('text", "html" or "template"');
         }
 
         $message['recipient-variables'] = json_encode($this->batchRecipientAttributes);

--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -230,6 +230,18 @@ class MessageBuilder
 
         return $this;
     }
+    /**
+     * Set template
+     *
+     * @param string $template Template name.
+     * @return self
+     */
+    public function setTemplate(string $template): self
+    {
+        $this->message['template'] = $template;
+
+        return $this;
+    }
 
     public function addCustomHeader(string $headerName, $headerData): self
     {

--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -230,11 +230,9 @@ class MessageBuilder
 
         return $this;
     }
+
     /**
-     * Set email template.
-     *
-     * @param string $template Template name.
-     * @return self
+     * @param string $template Name of the Mailgun template
      */
     public function setTemplate(string $template): self
     {

--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -231,7 +231,7 @@ class MessageBuilder
         return $this;
     }
     /**
-     * Set template
+     * Set email template.
      *
      * @param string $template Template name.
      * @return self

--- a/src/Message/README.md
+++ b/src/Message/README.md
@@ -1,22 +1,22 @@
 Mailgun - Messages
 ==================
 
-This is the Mailgun PHP *Message* utilities. 
+This is the Mailgun PHP *Message* utilities.
 
-The below assumes you've already installed the Mailgun PHP SDK in to your 
+The below assumes you've already installed the Mailgun PHP SDK in to your
 project. If not, go back to the master README for instructions.
 
-There are two utilities included, `MessageBuilder` and `BatchMessage`. 
+There are two utilities included, `MessageBuilder` and `BatchMessage`.
 
-* `MessageBuilder`: Allows you to build a message object by calling methods for 
-each MIME attribute. 
-* `BatchMessage`: Extends `MessageBuilder` and allows you to iterate through 
-recipients from a list. Messages will fire after the 1,000th recipient has been 
-added. 
+* `MessageBuilder`: Allows you to build a message object by calling methods for
+each MIME attribute.
+* `BatchMessage`: Extends `MessageBuilder` and allows you to iterate through
+recipients from a list. Messages will fire after the 1,000th recipient has been
+added.
 
 Usage - Message Builder
 -----------------------
-Here's how to use Message Builder to build your Message. 
+Here's how to use Message Builder to build your Message.
 
 ```php
 # Next, instantiate a Message Builder object from the SDK.
@@ -28,10 +28,12 @@ $builder->setFromAddress("me@example.com", array("first"=>"PHP", "last" => "SDK"
 $builder->addToRecipient("john.doe@example.com", array("first" => "John", "last" => "Doe"));
 # Define a cc recipient.
 $builder->addCcRecipient("sally.doe@example.com", array("full_name" => "Sally Doe"));
-# Define the subject. 
+# Define the subject.
 $builder->setSubject("A message from the PHP SDK using Message Builder!");
-# Define the body of the message.
+# Define the body of the message (One is required).
 $builder->setTextBody("This is the text body of the message!");
+$builder->setHtmlBody("<html><p>This is the HTML body of the message</p></html>");
+$builder->setTemplate("template_name");
 
 # Other Optional Parameters.
 $builder->addCampaignId("My-Awesome-Campaign");
@@ -48,10 +50,10 @@ $mg->messages()->send("example.com", $builder->getMessage());
 
 Usage - Batch Message
 ---------------------
-Here's how to use Batch Message to easily handle batch sending jobs. 
+Here's how to use Batch Message to easily handle batch sending jobs.
 
 ```php
-# First, instantiate the SDK with your API credentials and define your domain. 
+# First, instantiate the SDK with your API credentials and define your domain.
 $mg = new Mailgun("key-example");
 
 # Next, instantiate a Message Builder object from the SDK, pass in your sending domain.
@@ -59,17 +61,19 @@ $batchMessage = $mg->messages()->getBatchMessage("example.com");
 
 # Define the from address.
 $batchMessage->setFromAddress("me@example.com", array("first"=>"PHP", "last" => "SDK"));
-# Define the subject. 
+# Define the subject.
 $batchMessage->setSubject("A Batch Message from the PHP SDK!");
-# Define the body of the message.
-$batchMessage->setTextBody("This is the text body of the message!");
+# Define the body of the message (One is required).
+$builder->setTextBody("This is the text body of the message!");
+$builder->setHtmlBody("<html><p>This is the HTML body of the message</p></html>");
+$builder->setTemplate("template_name");
 
 # Next, let's add a few recipients to the batch job.
 $batchMessage->addToRecipient("john.doe@example.com", array("first" => "John", "last" => "Doe"));
 $batchMessage->addToRecipient("sally.doe@example.com", array("first" => "Sally", "last" => "Doe"));
 $batchMessage->addToRecipient("mike.jones@example.com", array("first" => "Mike", "last" => "Jones"));
 ...
-// After 1,000 recipients, Batch Message will automatically post your message to the messages endpoint. 
+// After 1,000 recipients, Batch Message will automatically post your message to the messages endpoint.
 
 // Call finalize() to send any remaining recipients still in the buffer.
 $batchMessage->finalize();
@@ -80,5 +84,5 @@ $messageIds = $batchMessage->getMessageIds();
 
 More Documentation
 ------------------
-See the official [Mailgun Docs](https://documentation.mailgun.com/en/latest/api-sending.html) 
+See the official [Mailgun Docs](https://documentation.mailgun.com/en/latest/api-sending.html)
 for more information.


### PR DESCRIPTION
Add function to set the template and only throw the error message when text, html and template variables are missing.
Also mention "setTextBody", "setHtmlBody" and the new "setTemplate" in the readme.

Before this, you had to use "setMessage" function to set all the variables including from, to, template, text/html etc if you wanted to use templates.