### PR TITLE
Remove redundant asserts caught by Psalm.

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -108,14 +108,10 @@ class Domain extends HttpApi
         }
 
         if (null !== $wildcard) {
-            Assert::boolean($wildcard);
-
             $params['wildcard'] = $wildcard ? 'true' : 'false';
         }
 
         if (null !== $forceDkimAuthority) {
-            Assert::boolean($forceDkimAuthority);
-
             $params['force_dkim_authority'] = $forceDkimAuthority ? 'true' : 'false';
         }
 
@@ -393,7 +389,6 @@ class Domain extends HttpApi
         Assert::stringNotEmpty($active);
         Assert::oneOf($active, ['yes', 'no', 'true', 'false']);
         Assert::stringNotEmpty($htmlFooter);
-        Assert::nullOrString($textFooter);
 
         $params = [
             'active' => (in_array($active, ['yes', 'true'], true)) ? 'true' : 'false',

--- a/src/Api/Ip.php
+++ b/src/Api/Ip.php
@@ -33,7 +33,6 @@ class Ip extends HttpApi
     {
         $params = [];
         if (null !== $dedicated) {
-            Assert::boolean($dedicated);
             $params['dedicated'] = $dedicated;
         }
 

--- a/src/Api/MailingList.php
+++ b/src/Api/MailingList.php
@@ -119,7 +119,6 @@ class MailingList extends HttpApi
     public function update(string $address, array $parameters = [])
     {
         Assert::stringNotEmpty($address);
-        Assert::isArray($parameters);
 
         foreach ($parameters as $field => $value) {
             switch ($field) {

--- a/src/Api/MailingList/Member.php
+++ b/src/Api/MailingList/Member.php
@@ -127,7 +127,6 @@ class Member extends HttpApi
     public function createMultiple(string $list, array $members, $upsert = false)
     {
         Assert::stringNotEmpty($list);
-        Assert::isArray($members);
 
         // workaround for webmozart/asserts <= 1.2
         if (count($members) > 1000) {
@@ -192,7 +191,6 @@ class Member extends HttpApi
     {
         Assert::stringNotEmpty($list);
         Assert::stringNotEmpty($address);
-        Assert::isArray($parameters);
 
         foreach ($parameters as $field => &$value) {
             switch ($field) {

--- a/src/Api/Message.php
+++ b/src/Api/Message.php
@@ -37,7 +37,6 @@ class Message extends HttpApi
      */
     public function send(string $domain, array $params)
     {
-        Assert::string($domain);
         Assert::notEmpty($domain);
         Assert::notEmpty($params);
 
@@ -73,11 +72,9 @@ class Message extends HttpApi
      */
     public function sendMime(string $domain, array $recipients, string $message, array $params)
     {
-        Assert::string($domain);
         Assert::notEmpty($domain);
         Assert::notEmpty($recipients);
         Assert::notEmpty($message);
-        Assert::nullOrIsArray($params);
 
         $params['to'] = $recipients;
         $postDataMultipart = $this->prepareMultipartParameters($params);

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -77,8 +77,6 @@ class Route extends HttpApi
      */
     public function create(string $expression, array $actions, string $description, int $priority = 0)
     {
-        Assert::isArray($actions);
-
         $params = [
             'priority' => (string) $priority,
             'expression' => $expression,


### PR DESCRIPTION
Psalm's static analysis found several cases where an `Assert` method was being used, but there was no point since the parameter type and if-statements already narrowed the type. This PR removes all those redundant assertions.