### PR TITLE
Use webhook signing key instead of API key for webhook signature verification

### DIFF
--- a/src/Api/Webhook.php
+++ b/src/Api/Webhook.php
@@ -32,12 +32,12 @@ class Webhook extends HttpApi
     /**
      * @var string
      */
-    private $apiKey;
+    private $signingKey;
 
-    public function __construct(ClientInterface $httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator, string $apiKey)
+    public function __construct(ClientInterface $httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator, string $signingKey)
     {
         parent::__construct($httpClient, $requestBuilder, $hydrator);
-        $this->apiKey = $apiKey;
+        $this->signingKey = $signingKey;
     }
 
     /**
@@ -48,11 +48,11 @@ class Webhook extends HttpApi
      */
     public function verifyWebhookSignature(int $timestamp, string $token, string $signature): bool
     {
-        if (empty($timestamp) || empty($token) || empty($signature)) {
+        if (empty($timestamp) || empty($token) || empty($signature) || empty($this->signingKey)) {
             return false;
         }
 
-        $hmac = hash_hmac('sha256', $timestamp.$token, $this->apiKey);
+        $hmac = hash_hmac('sha256', $timestamp.$token, $this->signingKey);
 
         if (function_exists('hash_equals')) {
             // hash_equals is constant time, but will not be introduced until PHP 5.6

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -139,7 +139,7 @@ class Mailgun
         return new Api\Tag($this->httpClient, $this->requestBuilder, $this->hydrator);
     }
 
-    public function webhooks(string $signingKey = ''): Api\Webhook
+    public function webhooks(string $signingKey): Api\Webhook
     {
         return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->hydrator, $signingKey);
     }

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -139,9 +139,9 @@ class Mailgun
         return new Api\Tag($this->httpClient, $this->requestBuilder, $this->hydrator);
     }
 
-    public function webhooks(): Api\Webhook
+    public function webhooks(string $signingKey = ''): Api\Webhook
     {
-        return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->hydrator, $this->apiKey);
+        return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->hydrator, $signingKey);
     }
 
     public function mailboxes(): Api\Mailboxes


### PR DESCRIPTION
When instantiating a `Mailgun` instance you are expected to provide an API key that is used to authenticate requests to the REST API.

```php
// First, instantiate the SDK with your API credentials
$mg = Mailgun::create('key-example');
```

This API key was passed to the `Api\Webhook` instance that is instantiated via `$mg->webhooks()`.

```php
public function webhooks(): Api\Webhook
{
    return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->hydrator, $this->apiKey);
}
```

https://github.com/mailgun/mailgun-php/blob/master/src/Mailgun.php#L142

This passed API key is used in the [`verifyWebhookSignature`](https://github.com/mailgun/mailgun-php/blob/master/src/Api/Webhook.php#L55) function. 

This will result in improper verification results as the account webhook signing key should be used to compute the signature, not the REST API key.

As is, you must manually instantiate an `Api\Webhook` instance to provide a webhook signing key and properly validate webhook signatures using this library.

```php
$webhook = new Webhook((new HttpClientConfigurator)->createConfiguredClient(), new RequestBuilder, new ModelHydrator,  'signing-key');
        
$webhook->verifyWebhookSignature($timestamp, $token, $signature); // This will work
```

This PR allows for passing a webhook signing key using the `$mg->webhooks('signing-key')` function. 