### PR TITLE
BatchMessage generates "invalid" JSON

### DIFF
--- a/src/Message/BatchMessage.php
+++ b/src/Message/BatchMessage.php
@@ -118,7 +118,7 @@ class BatchMessage extends MessageBuilder
             throw MissingRequiredParameter::create('text", "html" or "template');
         }
 
-        $message['recipient-variables'] = json_encode($this->batchRecipientAttributes);
+        $message['recipient-variables'] = json_encode($this->batchRecipientAttributes, JSON_FORCE_OBJECT);
         $response = $this->api->send($this->domain, $message);
 
         $this->batchRecipientAttributes = [];


### PR DESCRIPTION
The Mailgun messages API endpoint now seems to expect that all JSON provided keys have values or empty object.

Currently, empty keys are converted to arrays. This change forces it to be a JSON object.

Reference: https://github.com/mailgun/mailgun-php/issues/825