### PR TITLE
Fixed issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ phpunit.xml
 modd.conf
 .phpunit.result.cache
 .php_cs.cache
-.phpunit.result.cache
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 3.5.1
+
+### Fixed
+
+- Error with empty array for param recipient-variables. Fix was suggested by @deviarte
+- Use null coalescing operator in IndexResponse.php when. Fix proposed by @TWithers
+
 ## 3.5.0
 
 ### Added

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true">
-
-    <testsuites>
-        <testsuite name="Mailgun test suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Mailgun test suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.dist.bak
+++ b/phpunit.xml.dist.bak
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true">
+
+    <testsuites>
+        <testsuite name="Mailgun test suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Message/BatchMessage.php
+++ b/src/Message/BatchMessage.php
@@ -118,7 +118,7 @@ class BatchMessage extends MessageBuilder
             throw MissingRequiredParameter::create('text", "html" or "template');
         }
 
-        $message['recipient-variables'] = json_encode($this->batchRecipientAttributes);
+        $message['recipient-variables'] = json_encode($this->batchRecipientAttributes, JSON_FORCE_OBJECT);
         $response = $this->api->send($this->domain, $message);
 
         $this->batchRecipientAttributes = [];

--- a/src/Model/Ip/IndexResponse.php
+++ b/src/Model/Ip/IndexResponse.php
@@ -42,7 +42,7 @@ final class IndexResponse implements ApiResponse
         $model = new self();
         $model->items = $data['items'];
         $model->totalCount = $data['total_count'] ?? 0;
-        $model->assignableToPools = $data['assignable_to_pools'];
+        $model->assignableToPools = $data['assignable_to_pools'] ?? [];
 
         return $model;
     }

--- a/tests/Message/BatchMessageTest.php
+++ b/tests/Message/BatchMessageTest.php
@@ -184,11 +184,11 @@ class BatchMessageTest extends MailgunTestCase
 
     public function testEmptyRecipientForBatchMessage(): void
     {
-        $params =  [
-            'from'    => 'BATCH <example@gmail.com>',
-            'to'      => ['example@gmail.com'],
+        $params = [
+            'from' => 'BATCH <example@gmail.com>',
+            'to' => ['example@gmail.com'],
             'subject' => 'Hey %recipient.first%',
-            'text'    => 'If you wish to unsubscribe, click http://example.com/unsubscribe/%recipient.id%',
+            'text' => 'If you wish to unsubscribe, click http://example.com/unsubscribe/%recipient.id%',
             'recipient-variables' => [],
         ];
         $this->batchMessage->setMessage($params);

--- a/tests/Message/BatchMessageTest.php
+++ b/tests/Message/BatchMessageTest.php
@@ -181,4 +181,19 @@ class BatchMessageTest extends MailgunTestCase
         $this->expectException(MissingRequiredParameter::class);
         $this->batchMessage->finalize();
     }
+
+    public function testEmptyRecipientForBatchMessage(): void
+    {
+        $params =  [
+            'from'    => 'BATCH <example@gmail.com>',
+            'to'      => ['example@gmail.com'],
+            'subject' => 'Hey %recipient.first%',
+            'text'    => 'If you wish to unsubscribe, click http://example.com/unsubscribe/%recipient.id%',
+            'recipient-variables' => [],
+        ];
+        $this->batchMessage->setMessage($params);
+        $this->batchMessage->finalize();
+        $message = NSA::getProperty($this->batchMessage, 'message');
+        $this->assertEquals([], $message['recipient-variables']);
+    }
 }


### PR DESCRIPTION
 - BatchMessage generates "invalid" JSON for recipients with an empty set of recipient-variables
 - Use null coalescing operator in IndexResponse.php