### PR TITLE
close resources even if request failed

### DIFF
--- a/src/Api/EmailValidationV4.php
+++ b/src/Api/EmailValidationV4.php
@@ -73,8 +73,11 @@ class EmailValidationV4 extends HttpApi
         $postDataMultipart = [];
         $postDataMultipart[] = $this->prepareFile('file', $fileData);
 
-        $response = $this->httpPostRaw(sprintf('/v4/address/validate/bulk/%s', $listId), $postDataMultipart);
-        $this->closeResources($postDataMultipart);
+        try {
+            $response = $this->httpPostRaw(sprintf('/v4/address/validate/bulk/%s', $listId), $postDataMultipart);
+        } finally {
+            $this->closeResources($postDataMultipart);
+        }
 
         return $this->hydrateResponse($response, CreateBulkJobResponse::class);
     }
@@ -163,8 +166,11 @@ class EmailValidationV4 extends HttpApi
         $postDataMultipart = [];
         $postDataMultipart[] = $this->prepareFile('file', $fileData);
 
-        $response = $this->httpPostRaw(sprintf('/v4/address/validate/preview/%s', $previewId), $postDataMultipart);
-        $this->closeResources($postDataMultipart);
+        try {
+            $response = $this->httpPostRaw(sprintf('/v4/address/validate/preview/%s', $previewId), $postDataMultipart);
+        } finally {
+            $this->closeResources($postDataMultipart);
+        }
 
         return $this->hydrateResponse($response, CreateBulkPreviewResponse::class);
     }

--- a/src/Api/Message.php
+++ b/src/Api/Message.php
@@ -13,7 +13,6 @@ namespace Mailgun\Api;
 
 use Exception;
 use Mailgun\Assert;
-use Mailgun\Exception\HttpServerException;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Message\BatchMessage;
 use Mailgun\Model\Message\SendResponse;

--- a/src/Api/Message.php
+++ b/src/Api/Message.php
@@ -13,6 +13,7 @@ namespace Mailgun\Api;
 
 use Exception;
 use Mailgun\Assert;
+use Mailgun\Exception\HttpServerException;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Message\BatchMessage;
 use Mailgun\Model\Message\SendResponse;
@@ -65,8 +66,11 @@ class Message extends HttpApi
         }
 
         $postDataMultipart = array_merge($this->prepareMultipartParameters($params), $postDataMultipart);
-        $response = $this->httpPostRaw(sprintf('/v3/%s/messages', $domain), $postDataMultipart);
-        $this->closeResources($postDataMultipart);
+        try {
+            $response = $this->httpPostRaw(sprintf('/v3/%s/messages', $domain), $postDataMultipart);
+        } finally {
+            $this->closeResources($postDataMultipart);
+        }
 
         return $this->hydrateResponse($response, SendResponse::class);
     }
@@ -101,8 +105,11 @@ class Message extends HttpApi
             ];
         }
         $postDataMultipart[] = $this->prepareFile('message', $fileData);
-        $response = $this->httpPostRaw(sprintf('/v3/%s/messages.mime', $domain), $postDataMultipart);
-        $this->closeResources($postDataMultipart);
+        try {
+            $response = $this->httpPostRaw(sprintf('/v3/%s/messages.mime', $domain), $postDataMultipart);
+        } finally {
+            $this->closeResources($postDataMultipart);
+        }
 
         return $this->hydrateResponse($response, SendResponse::class);
     }


### PR DESCRIPTION
handle cases when Mailgun is used inside a long-running process (queue worker for example), catch the exception without closing the resources