### PR TITLE
Bugfix: TypeError caused by improper use of `new self()` instead of `new static()` in base class method (#878)

### DIFF
--- a/src/Model/Suppression/Bounce/Bounce.php
+++ b/src/Model/Suppression/Bounce/Bounce.php
@@ -21,13 +21,13 @@ class Bounce
     private $error;
     private $createdAt;
 
-    private function __construct()
+    final private function __construct()
     {
     }
 
     public static function create(array $data): self
     {
-        $model = new self();
+        $model = new static();
         $model->address = $data['address'] ?? null;
         $model->code = $data['code'] ?? null;
         $model->error = $data['error'] ?? null;

--- a/src/Model/Suppression/Complaint/Complaint.php
+++ b/src/Model/Suppression/Complaint/Complaint.php
@@ -19,13 +19,13 @@ class Complaint
     private $address;
     private $createdAt;
 
-    private function __construct()
+    final private function __construct()
     {
     }
 
     public static function create(array $data): self
     {
-        $model = new self();
+        $model = new static();
         $model->address = $data['address'] ?? null;
         $model->createdAt = isset($data['created_at']) ? new \DateTimeImmutable($data['created_at']) : null;
 

--- a/src/Model/Suppression/Unsubscribe/Unsubscribe.php
+++ b/src/Model/Suppression/Unsubscribe/Unsubscribe.php
@@ -20,13 +20,13 @@ class Unsubscribe
     private $createdAt;
     private $tags = [];
 
-    private function __construct()
+    final private function __construct()
     {
     }
 
     public static function create(array $data): self
     {
-        $model = new self();
+        $model = new static();
         $model->tags = $data['tags'] ?? [];
         $model->address = $data['address'] ?? null;
         $model->createdAt = isset($data['created_at']) ? new \DateTimeImmutable($data['created_at']) : null;

--- a/src/Model/Suppression/Whitelist/DeleteResponse.php
+++ b/src/Model/Suppression/Whitelist/DeleteResponse.php
@@ -27,7 +27,7 @@ final class DeleteResponse implements ApiResponse
 
     public static function create(array $data): self
     {
-        $model = new static();
+        $model = new self();
         $model->value = $data['value'] ?? '';
         $model->message = $data['message'] ?? '';
 

--- a/src/Model/Suppression/Whitelist/Whitelist.php
+++ b/src/Model/Suppression/Whitelist/Whitelist.php
@@ -23,13 +23,13 @@ class Whitelist
     private $type;
     private $createdAt;
 
-    private function __construct()
+    final private function __construct()
     {
     }
 
     public static function create(array $data): self
     {
-        $model = new self();
+        $model = new static();
         $model->value = $data['value'] ?? null;
         $model->reason = $data['reason'] ?? null;
         $model->type = $data['type'] ?? null;

--- a/tests/Model/Suppression/Whitelists/ShowResponseTest.php
+++ b/tests/Model/Suppression/Whitelists/ShowResponseTest.php
@@ -33,5 +33,6 @@ JSON;
         $this->assertEquals('why the record was created', $model->getReason());
         $this->assertEquals('address', $model->getType());
         $this->assertEquals('2011-10-21 11:02:55', $model->getCreatedAt()->format('Y-m-d H:i:s'));
+        $this->assertInstanceOf(ShowResponse::class, $model);
     }
 }


### PR DESCRIPTION
Attempt to fix issue #878 and added simple test for validation.

Particularly, for `final class DeleteResponse` , replaced 'new static()' with the more appropriate 'new self()', since it's a final class.