### PR TITLE
Fix README with the correct list of PSR-17 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ curl -sS https://getcomposer.org/installer | php
 The Mailgun API Client is not hard coupled to Guzzle, Buzz or any other library that sends
 HTTP messages. Instead, it uses the [PSR-18](https://www.php-fig.org/psr/psr-18/) client abstraction.
 This will give you the flexibility to choose what
-[PSR-7 implementation](https://packagist.org/providers/psr/http-message-implementation)
+[PSR-7 implementation](https://packagist.org/providers/psr/http-factory-implementation)
 and [HTTP client](https://packagist.org/providers/psr/http-client-implementation)
 you want to use.
 


### PR DESCRIPTION
According to the source, Mailgun uses `Discovery\Psr17FactoryDiscovery` and `Psr18ClientDiscovery`; thus, docs should like to factory and not message implementations.

Edit: just noticed that the mysterious package forced in my dependencies is indeed a provider of `psr/http-factory-implementation`, so it looks like my guesses for this commit seem correct :joy:

Related to #889.