### PR TITLE
fix documentation URLs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,7 @@
 # API documentation
 
 This page will document the API classes and ways to properly use the API. These resources will eventually move to
-the official documentation at [https://documentation.mailgun.com](https://documentation.mailgun.com/api_reference.html).
+the official documentation at [https://documentation.mailgun.com](https://documentation.mailgun.com/en/latest/api_reference.html).
 
 Other relevant documentation pages might be:
 

--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -33,7 +33,7 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-domains.html
+ * @see https://documentation.mailgun.com/en/latest/api-domains.html
  *
  * @author Sean Johnson <sean@mailgun.com>
  */
@@ -82,7 +82,7 @@ class Domain extends HttpApi
     /**
      * Creates a new domain for the account.
      * See below for spam filtering parameter information.
-     * {@link https://documentation.mailgun.com/user_manual.html#um-spam-filter}.
+     * {@link https://documentation.mailgun.com/en/latest/user_manual.html#um-spam-filter}.
      *
      * @see    https://documentation.mailgun.com/en/latest/api-domains.html#domains
      * @param  string                                 $domain             name of the domain
@@ -334,7 +334,7 @@ class Domain extends HttpApi
     /**
      * Update webScheme for existing domain
      * See below for spam filtering parameter information.
-     * {@link https://documentation.mailgun.com/user_manual.html#um-spam-filter}.
+     * {@link https://documentation.mailgun.com/en/latest/user_manual.html#um-spam-filter}.
      * @see https://documentation.mailgun.com/en/latest/api-domains.html#domains
      * @param  string                                    $domain         name of the domain
      * @param  string                                    $webScheme      `http` or `https` - set your open, click and unsubscribe URLs to use http or https. The default is http

--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -18,7 +18,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-domains.html
+ * @see https://documentation.mailgun.com/en/latest/api-domains.html
  *
  * @author Sean Johnson <sean@mailgun.com>
  */

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -20,7 +20,7 @@ use Mailgun\Model\Route\UpdateResponse;
 use Psr\Http\Client\ClientExceptionInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-routes.html
+ * @see https://documentation.mailgun.com/en/latest/api-routes.html
  *
  * @author David Garcia <me@davidgarcia.cat>
  */

--- a/src/Api/Suppression.php
+++ b/src/Api/Suppression.php
@@ -20,7 +20,7 @@ use Mailgun\Hydrator\Hydrator;
 use Psr\Http\Client\ClientInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-suppressions.html
+ * @see https://documentation.mailgun.com/en/latest/api-suppressions.html
  *
  * @author Sean Johnson <sean@mailgun.com>
  */

--- a/src/Api/Suppression/Bounce.php
+++ b/src/Api/Suppression/Bounce.php
@@ -21,7 +21,7 @@ use Mailgun\Model\Suppression\Bounce\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-suppressions.html#bounces
+ * @see https://documentation.mailgun.com/en/latest/api-suppressions.html#bounces
  * @author Sean Johnson <sean@mailgun.com>
  */
 class Bounce extends HttpApi

--- a/src/Api/Suppression/Complaint.php
+++ b/src/Api/Suppression/Complaint.php
@@ -21,7 +21,7 @@ use Mailgun\Model\Suppression\Complaint\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-suppressions.html#complaints
+ * @see https://documentation.mailgun.com/en/latest/api-suppressions.html#complaints
  *
  * @author Sean Johnson <sean@mailgun.com>
  */

--- a/src/Api/Suppression/Unsubscribe.php
+++ b/src/Api/Suppression/Unsubscribe.php
@@ -21,7 +21,7 @@ use Mailgun\Model\Suppression\Unsubscribe\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
 
 /**
- * @see https://documentation.mailgun.com/api-suppressions.html#unsubscribes
+ * @see https://documentation.mailgun.com/en/latest/api-suppressions.html#unsubscribes
  *
  * @author Sean Johnson <sean@mailgun.com>
  */


### PR DESCRIPTION
I found that URLs with out `/en/latest` are resulting in 404 errors:

- https://documentation.mailgun.com/api_reference.html
- https://documentation.mailgun.com/api-domains.html
- https://documentation.mailgun.com/api-routes.html
- https://documentation.mailgun.com/api-suppressions.html

Just adding this missing `/en/latest` fixes them.

I also fixed the https://documentation.mailgun.com/user_manual.html#um-spam-filter although that link seems to be incorrectly placed there, I'm not really sure, you'll guys have to take a look at that one.