### PR TITLE
Fixed PHP 8.4 deprecations

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -101,10 +101,10 @@ class Domain extends HttpApi
      */
     public function create(
         string $domain,
-        string $smtpPass = null,
-        string $spamAction = null,
-        bool $wildcard = null,
-        bool $forceDkimAuthority = null,
+        ?string $smtpPass = null,
+        ?string $spamAction = null,
+        ?bool $wildcard = null,
+        ?bool $forceDkimAuthority = null,
         ?array $ips = null,
         ?string $pool_id = null,
         string $webScheme = 'http',

--- a/src/Api/DomainV4.php
+++ b/src/Api/DomainV4.php
@@ -99,8 +99,8 @@ class DomainV4 extends HttpApi
      */
     public function create(
         string  $domain,
-        string  $smtpPass = null,
-        string  $spamAction = null,
+        ?string  $smtpPass = null,
+        ?string  $spamAction = null,
         ?bool $wildcard = null,
         ?bool $forceDkimAuthority = null,
         ?array  $ips = null,

--- a/src/Api/MailingList/Member.php
+++ b/src/Api/MailingList/Member.php
@@ -39,7 +39,7 @@ class Member extends HttpApi
      * @return IndexResponse
      * @throws ClientExceptionInterface
      */
-    public function index(string $address, int $limit = 100, bool $subscribed = null, array $requestHeaders = [])
+    public function index(string $address, int $limit = 100, ?bool $subscribed = null, array $requestHeaders = [])
     {
         Assert::stringNotEmpty($address);
         Assert::greaterThan($limit, 0);
@@ -92,7 +92,7 @@ class Member extends HttpApi
     public function create(
         string $list,
         string $address,
-        string $name = null,
+        ?string $name = null,
         array $vars = [],
         bool $subscribed = true,
         bool $upsert = false,

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -107,10 +107,10 @@ class Route extends HttpApi
      */
     public function update(
         string $routeId,
-        string $expression = null,
+        ?string $expression = null,
         array $actions = [],
-        string $description = null,
-        int $priority = null,
+        ?string $description = null,
+        ?int $priority = null,
         array $requestHeaders = []
     ) {
         Assert::stringNotEmpty($routeId);

--- a/src/Api/Suppression/Complaint.php
+++ b/src/Api/Suppression/Complaint.php
@@ -73,7 +73,7 @@ class Complaint extends HttpApi
      * @return CreateResponse
      * @throws ClientExceptionInterface
      */
-    public function create(string $domain, string $address, string $createdAt = null, array $requestHeaders = [])
+    public function create(string $domain, string $address, ?string $createdAt = null, array $requestHeaders = [])
     {
         Assert::stringNotEmpty($domain);
         Assert::stringNotEmpty($address);

--- a/src/Api/Suppression/Unsubscribe.php
+++ b/src/Api/Suppression/Unsubscribe.php
@@ -95,7 +95,7 @@ class Unsubscribe extends HttpApi
      * @return DeleteResponse
      * @throws ClientExceptionInterface
      */
-    public function delete(string $domain, string $address, string $tag = null, array $requestHeaders = [])
+    public function delete(string $domain, string $address, ?string $tag = null, array $requestHeaders = [])
     {
         Assert::stringNotEmpty($domain);
         Assert::stringNotEmpty($address);

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -77,8 +77,8 @@ class Mailgun
      */
     public function __construct(
         HttpClientConfigurator $configurator,
-        Hydrator $hydrator = null,
-        RequestBuilder $requestBuilder = null
+        ?Hydrator $hydrator = null,
+        ?RequestBuilder $requestBuilder = null
     ) {
         $this->requestBuilder = $requestBuilder ?: new RequestBuilder();
         $this->hydrator = $hydrator ?: new ModelHydrator();

--- a/src/Message/Exceptions/MissingRequiredParameter.php
+++ b/src/Message/Exceptions/MissingRequiredParameter.php
@@ -20,7 +20,7 @@ class MissingRequiredParameter extends \Exception implements Exception
      * @param string|null $message
      * @return self
      */
-    public static function create(string $parameter, string $message = null)
+    public static function create(string $parameter, ?string $message = null)
     {
         if (null === $message) {
             $message = 'The parameters passed to the API were invalid. Please specify "%s".';

--- a/src/Message/MessageBuilder.php
+++ b/src/Message/MessageBuilder.php
@@ -318,7 +318,7 @@ class MessageBuilder
      * @param  string|null $attachmentName
      * @return $this
      */
-    public function addAttachment(string $attachmentPath, string $attachmentName = null): self
+    public function addAttachment(string $attachmentPath, ?string $attachmentName = null): self
     {
         if (!isset($this->message['attachment'])) {
             $this->message['attachment'] = [];
@@ -337,7 +337,7 @@ class MessageBuilder
      * @param  string|null $attachmentName
      * @return $this
      */
-    public function addStringAttachment(string $attachmentContent, string $attachmentName = null): self
+    public function addStringAttachment(string $attachmentContent, ?string $attachmentName = null): self
     {
         if (!isset($this->message['attachment'])) {
             $this->message['attachment'] = [];
@@ -356,7 +356,7 @@ class MessageBuilder
      * @param  string|null $inlineImageName
      * @return $this
      */
-    public function addInlineImage(string $inlineImagePath, string $inlineImageName = null): self
+    public function addInlineImage(string $inlineImagePath, ?string $inlineImageName = null): self
     {
         if (!isset($this->message['inline'])) {
             $this->message['inline'] = [];
@@ -466,7 +466,7 @@ class MessageBuilder
      * @return $this
      * @throws \Exception
      */
-    public function setDeliveryTime(string $timeDate, string $timeZone = null): self
+    public function setDeliveryTime(string $timeDate, ?string $timeZone = null): self
     {
         if (null !== $timeZone) {
             $timeZoneObj = new DateTimeZone($timeZone);


### PR DESCRIPTION
Fixed deprecations notices in PHP 8.4 like `Implicitly marking parameter ... as nullable is deprecated, the explicit nullable type must be used instead`