### PR TITLE
## 4.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 4.3.5
+- Implemented `AccountManagement` API endpoints:
+    - `updateAccountSettings` for `PUT /v5/accounts`
+    - `getHttpSigningKey` for `GET /v5/accounts/http_signing_key`
+    - `createHttpSigningKey` for `POST /v5/accounts/http_signing_key`
+    - `getSandboxAuthRecipients` for `GET /v5/sandbox/auth_recipients`
+- Added model classes for `AccountManagement` API responses:
+    - `AccountResponse`
+    - `HttpSigningKeyResponse`
+    - `SandboxAuthRecipientsResponse`
+- Updated `Mailgun` class to include `AccountManagement` API.
+
 ## 4.3.4
  - Extended limit of tags to 10.
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -56,3 +56,46 @@ try {
 }
 
 ```
+
+
+## Account Management Examples
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Mailgun\Mailgun;
+
+$mgClient = Mailgun::create('xxx');
+$domain = "yyy.mailgun.org";
+
+try {
+    $res = $mgClient->accountManagement()->addRecipientSandbox('xxx@gmail.com');
+    print_r($res);
+} catch (Throwable $t) {
+    print_r($t->getMessage());
+    print_r($t->getTraceAsString());
+}
+
+try {
+    $res = $mgClient->accountManagement()->getSandboxAuthRecipients();
+    print_r($res);
+} catch (Throwable $t) {
+    print_r($t->getMessage());
+    print_r($t->getTraceAsString());
+}
+
+try {
+    $res = $mgClient->accountManagement()->getHttpSigningKey();
+    print_r($res);
+} catch (Throwable $t) {
+    print_r($t->getMessage());
+    print_r($t->getTraceAsString());
+}
+
+
+
+
+//print_r($res);
+
+```

--- a/src/Api/AccountManagement.php
+++ b/src/Api/AccountManagement.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailgun\Api;
+
+use Mailgun\Model\AccountManagement\AccountResponse;
+use Mailgun\Model\AccountManagement\HttpSigningKeyResponse;
+use Mailgun\Model\AccountManagement\SandboxAuthRecipientsResponse;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class AccountManagement extends HttpApi
+{
+    /**
+     * Updates account settings.
+     * @param array $params
+     * @param array $requestHeaders
+     * @return AccountResponse|array|ResponseInterface
+     * @throws ClientExceptionInterface|\JsonException
+     * @throws \Exception
+     */
+    public function updateAccountSettings(array $params, array $requestHeaders = [])
+    {
+        $response = $this->httpPut('/v5/accounts', $params, $requestHeaders);
+
+        return $this->hydrateResponse($response, AccountResponse::class);
+    }
+
+    /**
+     * Retrieves the HTTP signing key.
+     * @param array $requestHeaders
+     * @return HttpSigningKeyResponse|array|ResponseInterface
+     * @throws ClientExceptionInterface
+     * @throws \Exception
+     */
+    public function getHttpSigningKey(array $requestHeaders = [])
+    {
+        $response = $this->httpGet('/v5/accounts/http_signing_key', [], $requestHeaders);
+
+        return $this->hydrateResponse($response, HttpSigningKeyResponse::class);
+    }
+
+    /**
+     * Creates a new HTTP signing key.
+     * @param array $requestHeaders
+     * @return HttpSigningKeyResponse|array|ResponseInterface
+     * @throws ClientExceptionInterface
+     * @throws \JsonException
+     * @throws \Exception
+     */
+    public function createHttpSigningKey(array $requestHeaders = [])
+    {
+        $response = $this->httpPost('/v5/accounts/http_signing_key', [], $requestHeaders);
+
+        return $this->hydrateResponse($response, HttpSigningKeyResponse::class);
+    }
+
+    /**
+     * Retrieves the list of sandbox authorized recipients.
+     * @param array $requestHeaders
+     * @return SandboxAuthRecipientsResponse|array|ResponseInterface
+     * @throws ClientExceptionInterface
+     * @throws \Exception
+     */
+    public function getSandboxAuthRecipients(array $requestHeaders = [])
+    {
+        $response = $this->httpGet('/v5/sandbox/auth_recipients', [], $requestHeaders);
+
+        return $this->hydrateResponse($response, SandboxAuthRecipientsResponse::class);
+    }
+
+    /**
+     * Add authorized email recipient for a sandbox domain
+     * @param string $email
+     * @param array $requestHeaders
+     * @return SandboxAuthRecipientsResponse|array|ResponseInterface
+     * @throws ClientExceptionInterface
+     * @throws \JsonException
+     * @throws \Exception
+     */
+    public function addRecipientSandbox(string $email, array $requestHeaders = [])
+    {
+        $response = $this->httpPost('/v5/sandbox/auth_recipients', ['email' => $email], $requestHeaders);
+
+        return $this->hydrateResponse($response, SandboxAuthRecipientsResponse::class);
+    }
+}

--- a/src/Api/AccountManagement.php
+++ b/src/Api/AccountManagement.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Api;
 
 use Mailgun\Model\AccountManagement\AccountResponse;

--- a/src/Api/Suppression/Complaint.php
+++ b/src/Api/Suppression/Complaint.php
@@ -19,6 +19,8 @@ use Mailgun\Model\Suppression\Complaint\DeleteResponse;
 use Mailgun\Model\Suppression\Complaint\IndexResponse;
 use Mailgun\Model\Suppression\Complaint\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * @see https://documentation.mailgun.com/en/latest/api-suppressions.html#complaints
@@ -119,5 +121,26 @@ class Complaint extends HttpApi
         $response = $this->httpDelete(sprintf('/v3/%s/complaints', $domain), [], $requestHeaders);
 
         return $this->hydrateResponse($response, DeleteResponse::class);
+    }
+
+    /**
+     * @param string $domainId
+     * @param array $complaints
+     * @param array $requestHeaders
+     * @return mixed
+     */
+    public function importComplaints(string $domainId, array $complaints, array $requestHeaders = [])
+    {
+        try {
+            $response = $this->httpPostRaw(
+                sprintf('/v3/%s/complaints/import', $domainId),
+                $complaints,
+                $requestHeaders
+            );
+        } catch (Throwable $throwable) {
+            throw new RuntimeException($throwable->getMessage());
+        }
+
+        return $this->hydrateResponse($response, ShowResponse::class);
     }
 }

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Mailgun;
 
 use Http\Client\Common\PluginClient;
+use Mailgun\Api\AccountManagement;
 use Mailgun\Api\Attachment;
 use Mailgun\Api\Domain;
 use Mailgun\Api\DomainKeys;
@@ -271,5 +272,13 @@ class Mailgun
     public function domainKeys(): Api\DomainKeys
     {
         return new Api\DomainKeys($this->httpClient, $this->requestBuilder, $this->hydrator);
+    }
+
+    /**
+     * @return AccountManagement
+     */
+    public function accountManagement(): AccountManagement
+    {
+        return new AccountManagement($this->httpClient, $this->requestBuilder, $this->hydrator);
     }
 }

--- a/src/Model/AccountManagement/AccountResponse.php
+++ b/src/Model/AccountManagement/AccountResponse.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Model\AccountManagement;
 
 use Mailgun\Model\ApiResponse;

--- a/src/Model/AccountManagement/AccountResponse.php
+++ b/src/Model/AccountManagement/AccountResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailgun\Model\AccountManagement;
+
+use Mailgun\Model\ApiResponse;
+
+final class AccountResponse implements ApiResponse
+{
+    private string $message;
+
+    public static function create(array $data): self
+    {
+        $model = new self();
+        $model->message = $data['message'] ?? '';
+
+        return $model;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Model/AccountManagement/HttpSigningKeyResponse.php
+++ b/src/Model/AccountManagement/HttpSigningKeyResponse.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Model\AccountManagement;
 
 use Mailgun\Model\ApiResponse;

--- a/src/Model/AccountManagement/HttpSigningKeyResponse.php
+++ b/src/Model/AccountManagement/HttpSigningKeyResponse.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailgun\Model\AccountManagement;
+
+use Mailgun\Model\ApiResponse;
+
+final class HttpSigningKeyResponse implements ApiResponse
+{
+    private string $key;
+    private string $createdAt;
+    private string $httpSigningKey;
+    private string $message;
+
+    /**
+     * @param array $data
+     * @return self
+     */
+    public static function create(array $data): self
+    {
+        $model = new self();
+        $model->key = $data['key'] ?? '';
+        $model->createdAt = $data['created_at'] ?? '';
+        $model->httpSigningKey = $data['http_signing_key'] ?? '';
+        $model->message = $data['message'] ?? '';
+
+        return $model;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpSigningKey(): string
+    {
+        return $this->httpSigningKey;
+    }
+
+    /**
+     * @param string $httpSigningKey
+     * @return void
+     */
+    public function setHttpSigningKey(string $httpSigningKey): void
+    {
+        $this->httpSigningKey = $httpSigningKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     * @return void
+     */
+    public function setMessage(string $message): void
+    {
+        $this->message = $message;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Model/AccountManagement/SandboxAuthRecipientsResponse.php
+++ b/src/Model/AccountManagement/SandboxAuthRecipientsResponse.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * Copyright (C) 2013 Mailgun
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 namespace Mailgun\Model\AccountManagement;
 
 use Mailgun\Model\ApiResponse;

--- a/src/Model/AccountManagement/SandboxAuthRecipientsResponse.php
+++ b/src/Model/AccountManagement/SandboxAuthRecipientsResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailgun\Model\AccountManagement;
+
+use Mailgun\Model\ApiResponse;
+
+final class SandboxAuthRecipientsResponse implements ApiResponse
+{
+    private array $recipients;
+
+    /**
+     * @param array $data
+     * @return self
+     */
+    public static function create(array $data): self
+    {
+        $model = new self();
+        $model->recipients = $data['recipients'] ?? $data['recipient'] ?? [];
+
+        return $model;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRecipients(): array
+    {
+        return $this->recipients;
+    }
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
### Added
- Implemented `AccountManagement` API endpoints:
  - `updateAccountSettings` for `PUT /v5/accounts`
  - `getHttpSigningKey` for `GET /v5/accounts/http_signing_key`
  - `createHttpSigningKey` for `POST /v5/accounts/http_signing_key`
  - `getSandboxAuthRecipients` for `GET /v5/sandbox/auth_recipients`
- Added model classes for `AccountManagement` API responses:
  - `AccountResponse`
  - `HttpSigningKeyResponse`
  - `SandboxAuthRecipientsResponse`
- Updated `Mailgun` class to include `AccountManagement` API.