### PR TITLE
Use ubuntu-latest for all CI runs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -71,7 +71,7 @@ jobs:
 
   composer-normalize:
     name: Composer Normalize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
CI was failing when running on `ubuntu-20.04` because it's no longer supported by GitHub.