### PR TITLE
preserve previous exception when rethrowing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php-http/discovery": "^1.19",
         "php-http/multipart-stream-builder": "^1.1.2",
         "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "webmozart/assert": "^1.9.1"
     },
     "require-dev": {

--- a/src/Api/EmailValidationV4.php
+++ b/src/Api/EmailValidationV4.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace Mailgun\Api;
 
-use Exception;
 use Mailgun\Assert;
+use Mailgun\Message\Exceptions\RuntimeException;
 use Mailgun\Model\EmailValidationV4\CreateBulkJobResponse;
 use Mailgun\Model\EmailValidationV4\CreateBulkPreviewResponse;
 use Mailgun\Model\EmailValidationV4\DeleteBulkJobResponse;
@@ -24,7 +24,7 @@ use Mailgun\Model\EmailValidationV4\PromoteBulkPreviewResponse;
 use Mailgun\Model\EmailValidationV4\ValidateResponse;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
+use Throwable;
 
 /**
  * @see https://documentation.mailgun.com/docs/inboxready/api-reference/openapi-validate-final/validations
@@ -58,7 +58,7 @@ class EmailValidationV4 extends HttpApi
      * @param  string                             $listId   ID given when the list created
      * @param  mixed                              $filePath File path or file content
      * @return mixed|ResponseInterface
-     * @throws Exception|ClientExceptionInterface
+     * @throws ClientExceptionInterface
      */
     public function createBulkJob(string $listId, $filePath, array $requestHeaders = [])
     {
@@ -78,8 +78,8 @@ class EmailValidationV4 extends HttpApi
 
         try {
             $response = $this->httpPostRaw(sprintf('/v4/address/validate/bulk/%s', $listId), $postDataMultipart, $requestHeaders);
-        } catch (Exception $exception) {
-            throw new RuntimeException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new RuntimeException($throwable->getMessage(), 0, $throwable);
         } finally {
             $this->closeResources($postDataMultipart);
         }
@@ -184,8 +184,8 @@ class EmailValidationV4 extends HttpApi
 
         try {
             $response = $this->httpPostRaw(sprintf('/v4/address/validate/preview/%s', $previewId), $postDataMultipart, $requestHeaders);
-        } catch (Exception $exception) {
-            throw new RuntimeException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new RuntimeException($throwable->getMessage(), 0, $throwable);
         } finally {
             $this->closeResources($postDataMultipart);
         }

--- a/src/Api/HttpApi.php
+++ b/src/Api/HttpApi.php
@@ -18,9 +18,11 @@ use Mailgun\Exception\UnknownErrorException;
 use Mailgun\HttpClient\RequestBuilder;
 use Mailgun\Hydrator\Hydrator;
 use Mailgun\Hydrator\NoopHydrator;
+use Mailgun\Message\Exceptions\RuntimeException;
 use Psr\Http\Client as Psr18;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -82,7 +84,7 @@ abstract class HttpApi
     /**
      * Throw the correct exception for this error.
      *
-     * @throws Exception|UnknownErrorException
+     * @throws HttpClientException|UnknownErrorException
      */
     protected function handleErrors(ResponseInterface $response): void
     {
@@ -117,7 +119,7 @@ abstract class HttpApi
      * @param  string                   $path           Request path
      * @param  array                    $parameters     GET parameters
      * @param  array                    $requestHeaders Request Headers
-     * @throws ClientExceptionInterface|\JsonException
+     * @throws RuntimeException|ClientExceptionInterface|RequestExceptionInterface|\JsonException
      */
     protected function httpGet(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {
@@ -142,7 +144,7 @@ abstract class HttpApi
      * @param  string                   $path           Request path
      * @param  array                    $parameters     POST parameters
      * @param  array                    $requestHeaders Request headers
-     * @throws ClientExceptionInterface|\JsonException
+     * @throws RuntimeException|ClientExceptionInterface|RequestExceptionInterface|\JsonException
      */
     protected function httpPost(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {
@@ -159,7 +161,7 @@ abstract class HttpApi
      * @param  string                   $path           Request path
      * @param  array|string             $body           Request body
      * @param  array                    $requestHeaders Request headers
-     * @throws ClientExceptionInterface|\JsonException
+     * @throws RuntimeException|ClientExceptionInterface|RequestExceptionInterface|\JsonException
      */
     protected function httpPostRaw(string $path, $body, array $requestHeaders = []): ResponseInterface
     {
@@ -180,7 +182,7 @@ abstract class HttpApi
      * @param  string                   $path           Request path
      * @param  array                    $parameters     PUT parameters
      * @param  array                    $requestHeaders Request headers
-     * @throws ClientExceptionInterface|\JsonException
+     * @throws RuntimeException|ClientExceptionInterface|RequestExceptionInterface|\JsonException
      */
     protected function httpPut(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {
@@ -201,7 +203,7 @@ abstract class HttpApi
      * @param  string                   $path           Request path
      * @param  array                    $parameters     PATCH parameters
      * @param  array                    $requestHeaders Request headers
-     * @throws ClientExceptionInterface|\JsonException
+     * @throws RuntimeException|ClientExceptionInterface|RequestExceptionInterface|\JsonException
      */
     protected function httpPatch(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {
@@ -222,7 +224,7 @@ abstract class HttpApi
      * @param  string                   $path           Request path
      * @param  array                    $parameters     DELETE parameters
      * @param  array                    $requestHeaders Request headers
-     * @throws ClientExceptionInterface
+     * @throws RuntimeException|ClientExceptionInterface|RequestExceptionInterface|\JsonException
      */
     protected function httpDelete(string $path, array $parameters = [], array $requestHeaders = []): ResponseInterface
     {

--- a/src/Api/Message.php
+++ b/src/Api/Message.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
 
 namespace Mailgun\Api;
 
-use Exception;
 use Mailgun\Assert;
 use Mailgun\Exception\InvalidArgumentException;
 use Mailgun\Message\BatchMessage;
+use Mailgun\Message\Exceptions\RuntimeException;
 use Mailgun\Model\Message\QueueStatusResponse;
 use Mailgun\Model\Message\SendResponse;
 use Mailgun\Model\Message\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
+use Throwable;
 
 /**
  * @see https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/messages
@@ -71,8 +71,8 @@ class Message extends HttpApi
         $postDataMultipart = array_merge($this->prepareMultipartParameters($params), $postDataMultipart);
         try {
             $response = $this->httpPostRaw(sprintf('/v3/%s/messages', $domain), $postDataMultipart, $requestHeaders);
-        } catch (Exception $exception) {
-            throw new RuntimeException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new RuntimeException($throwable->getMessage(), 0, $throwable);
         } finally {
             $this->closeResources($postDataMultipart);
         }
@@ -112,8 +112,8 @@ class Message extends HttpApi
         $postDataMultipart[] = $this->prepareFile('message', $fileData);
         try {
             $response = $this->httpPostRaw(sprintf('/v3/%s/messages.mime', $domain), $postDataMultipart, $requestHeaders);
-        } catch (Exception $exception) {
-            throw new RuntimeException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new RuntimeException($throwable->getMessage(), 0, $throwable);
         } finally {
             $this->closeResources($postDataMultipart);
         }

--- a/src/Api/Suppression/Bounce.php
+++ b/src/Api/Suppression/Bounce.php
@@ -14,12 +14,12 @@ namespace Mailgun\Api\Suppression;
 use Mailgun\Api\HttpApi;
 use Mailgun\Api\Pagination;
 use Mailgun\Assert;
+use Mailgun\Message\Exceptions\RuntimeException;
 use Mailgun\Model\Suppression\Bounce\CreateResponse;
 use Mailgun\Model\Suppression\Bounce\DeleteResponse;
 use Mailgun\Model\Suppression\Bounce\IndexResponse;
 use Mailgun\Model\Suppression\Bounce\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -135,7 +135,7 @@ class Bounce extends HttpApi
                 $requestHeaders
             );
         } catch (Throwable $throwable) {
-            throw new RuntimeException($throwable->getMessage());
+            throw new RuntimeException($throwable->getMessage(), 0, $throwable);
         }
 
         return $this->hydrateResponse($response, CreateResponse::class);

--- a/src/Api/Suppression/Complaint.php
+++ b/src/Api/Suppression/Complaint.php
@@ -14,12 +14,12 @@ namespace Mailgun\Api\Suppression;
 use Mailgun\Api\HttpApi;
 use Mailgun\Api\Pagination;
 use Mailgun\Assert;
+use Mailgun\Message\Exceptions\RuntimeException;
 use Mailgun\Model\Suppression\Complaint\CreateResponse;
 use Mailgun\Model\Suppression\Complaint\DeleteResponse;
 use Mailgun\Model\Suppression\Complaint\IndexResponse;
 use Mailgun\Model\Suppression\Complaint\ShowResponse;
 use Psr\Http\Client\ClientExceptionInterface;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -138,7 +138,7 @@ class Complaint extends HttpApi
                 $requestHeaders
             );
         } catch (Throwable $throwable) {
-            throw new RuntimeException($throwable->getMessage());
+            throw new RuntimeException($throwable->getMessage(), 0, $throwable);
         }
 
         return $this->hydrateResponse($response, ShowResponse::class);


### PR DESCRIPTION
This PR adds some minor improvements:

**Preserve previous exception when rethrowing**
Currently exceptions on some functions are caught and rethrown. In `HttpApi` the previous exception is preserved, but not in some other classes. This makes debugging problems hard because the exception that is the root cause of the issue is swallowed.
This change is backwards compatible, it only populates the `$previous` parameter of the exception already being thrown.

**Add missing dependency `psr/http-message`**
The class `HttpApi` uses `Psr\Http\Message\ResponseInterface` which is part of `psr/http-message`, but that package was not part of the `require` section in `composer.json`.
This change is backwards compatible, `psr/http-message` was already being pulled in as a transitive dependecy.

**Use `Mailgun\Message\Exceptions\RuntimeException`**
This package has its own `Mailgun\Message\Exceptions\RuntimeException`, but the classes `EmailValidationV4`, `Message`, `Bounce` and `Complaint` were (by accident?) importing PHP's root `RuntimeException`. The imports have been updated to point to the correct namespace. This will allow a `catch` to isolate exceptions better.
This change is backwards compatible, `Mailgun\Message\Exceptions\RuntimeException` extends from `\RuntimeException` so any `catch` in downstream projects will still catch the exception.

**Updated PHPDoc `@throws` tags in `HttpApi`**
Updated the `@throws` tags in the `HttpApi` class to correctly reflect which exceptions can be thrown based on the code paths that I saw.
This change is backwards compatible, it only changes PHPDoc blocks and does not touch any code implementation.
