### PR TITLE
- `Mailgun::webhooks()` no longer requires an explicit `$signingKey` …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 4.5.1
+
+### Fixed
+
+- `Mailgun::webhooks()` no longer requires an explicit `$signingKey` argument.
+  When omitted, it falls back to the API key stored on the `Mailgun` instance,
+  restoring compatibility with pre-v4.3.7 usage patterns (issue #947).
+
 ## 4.5.0
 
 ### Added

--- a/src/Api/Webhook.php
+++ b/src/Api/Webhook.php
@@ -38,7 +38,7 @@ class Webhook extends HttpApi
      * @param Hydrator $hydrator
      * @param string|null $signingKey
      */
-    public function __construct($httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator, ?string $signingKey)
+    public function __construct($httpClient, RequestBuilder $requestBuilder, Hydrator $hydrator, ?string $signingKey = null)
     {
         parent::__construct($httpClient, $requestBuilder, $hydrator);
         $this->signingKey = $signingKey;

--- a/src/Mailgun.php
+++ b/src/Mailgun.php
@@ -222,9 +222,9 @@ class Mailgun
     /**
      * @return Webhook
      */
-    public function webhooks(string $signingKey): Api\Webhook
+    public function webhooks(?string $signingKey = null): Api\Webhook
     {
-        return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->hydrator, $signingKey);
+        return new Api\Webhook($this->httpClient, $this->requestBuilder, $this->hydrator, $signingKey ?? $this->apiKey);
     }
 
     /**

--- a/tests/Api/WebhookTest.php
+++ b/tests/Api/WebhookTest.php
@@ -53,6 +53,13 @@ class WebhookTest extends TestCase
         $this->assertFalse($api->verifyWebhookSignature(0, '', ''));
     }
 
+    public function testVerifyWebhookWithNoSigningKey()
+    {
+        $api = $this->getApiInstance();
+
+        $this->assertFalse($api->verifyWebhookSignature(1403645220, 'sometoken', 'somesig'));
+    }
+
     public function testIndex()
     {
         $this->setRequestMethod('GET');


### PR DESCRIPTION
…argument.

  When omitted, it falls back to the API key stored on the `Mailgun` instance,
  restoring compatibility with pre-v4.3.7 usage patterns (issue #947).